### PR TITLE
Add ChatType to guard.ChannelInfo + fix hardcoded 'chat' in reports (glm-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,90 @@
+# Changelog
+
+All notable changes to **telegram-nda-guard** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project aims to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## How this project uses the changelog
+
+`telegram-nda-guard` is a framework: other projects consume its packages
+(`controllers/scanner`, `processors/*`, `storage/*`, `telegram/*`) and implement
+its interfaces. **Any change to a public interface, constructor, functional option,
+or DTO that consumers depend on must be recorded here** so consumers can migrate.
+
+Each release section contains:
+
+- **Added** — new capabilities, new interface methods, new options, new packages.
+- **Changed** — modifications to existing behavior, signatures, or defaults.
+- **Deprecated** — soon-to-be-removed features.
+- **Removed** — deleted capabilities (always breaking).
+- **Fixed** — bug fixes.
+- **Migration** — concrete steps consumers must take when a change is breaking or
+  requires wiring adjustments. If an interface gained a method, `Migration` lists
+  every other implementation (including custom ones) that must add it.
+
+When in doubt, add a `Migration` note. It is cheaper than a silent break.
+
+---
+
+## [Unreleased]
+
+### Added
+
+- `guard.ChannelInfo.Type` (`string`) — the Telegram chat type, plus
+  `ChatType*` constants (`ChatTypePrivate`, `ChatTypeGroup`,
+  `ChatTypeSupergroup`, `ChatTypeChannel`) and a `guard.ChatTypeNoun(type)`
+  helper that returns `"channel"` for broadcast channels and `"chat"`
+  otherwise. This lets consumers distinguish channels from chats/groups.
+  `bots/bot.GetChat` now populates `Type` from the Bot API response, and the
+  scan/clean reports (reporter and kicker) use the correct noun instead of the
+  hardcoded "chat".
+- Established this `CHANGELOG.md` and the migration-note convention documented
+  above. Future interface/contract changes will be recorded under this section
+  until the next tagged release.
+
+### Migration
+
+No action required for consumers at this point. This entry only formalizes the
+changelog going forward.
+
+---
+
+## [0.1.0] — 2024 (full refactoring, no backward compatibility)
+
+### Changed
+
+- **Breaking:** project-wide refactoring. The phone-auth user bot was removed;
+  the user bot now uses the bot account (more secure). The `SessionStorage`
+  contract was changed to match the new userbot version. Existing callers that
+  constructed the previous user bot / session storage need to be updated to the
+  new constructors and options.
+
+### Migration
+
+This release intentionally broke backward compatibility. Consumers must:
+
+1. Update user bot construction to the new bot-account-based flow.
+2. Update `SessionStorage` implementations to the new method contract.
+3. Review `cmd/example/main.go` for the current wiring reference.
+
+> Note: this historical release shipped **without** a migration document at the
+> time. It is recorded here retroactively for completeness.
+
+---
+
+## Conventional locations of the consumer-facing interfaces
+
+The framework's public surface lives in these files. Changes here are the most
+likely to require a `Migration` note:
+
+| Interface / type | File | Purpose |
+|---|---|---|
+| `guard.User`, `guard.ChannelInfo`, `guard.Message`, `guard.InlineButton`, `guard.Permission` | `defs.go` | Core domain DTOs |
+| `scanner.ProtectedChannelStorage`, `scanner.Logger`, `scanner.UserReportProcessor`, `scanner.CheckUserAccess`, `scanner.UserBot`, `scanner.TelegramBot` | `controllers/scanner/dep.go` | Controller-side contracts |
+| `scanner.ProtectedChannel`, `scanner.ChannelInfo` (controller), `scanner.ScanRequest` | `controllers/scanner/defs.go` | Controller domain model |
+| `scanner.ProcessorOption` + `With*` options | `controllers/scanner/options.go` | Controller configuration |
+| `processors.AccessReport` | `processors/defs.go` | Report DTO shared with processors |
+| `kicker.TelegramBotUserKicker`, `kicker.Option` | `processors/kicker/dep.go`, `options.go` | Cleaner processor contract |
+| `reporter.TelegramBotMessageSender`, `reporter.Option` | `processors/reporter/dep.go`, `options.go` | Reporter processor contract |
+| `channels.ProtectedChannel` (storage model) | `storage/channels/defs.go` | Persisted channel model |

--- a/controllers/scanner/channel_users_checker.go
+++ b/controllers/scanner/channel_users_checker.go
@@ -98,6 +98,7 @@ func (d *Domain) ProcessRequest(ctx context.Context, request ScanRequest) {
 		Channel: guard.ChannelInfo{
 			ID:    request.channelInfo.id,
 			Title: request.channelInfo.title,
+			Type:  request.channelInfo.chatType,
 		},
 		AllowedUsers: []guard.User{},
 		DeniedUsers:  []guard.User{},

--- a/controllers/scanner/defs.go
+++ b/controllers/scanner/defs.go
@@ -5,6 +5,7 @@ type ChannelInfo struct {
 	id                int64
 	commandChannelIDs []int64
 	title             string
+	chatType          string
 	botOnChannel      bool
 	botCanInvite      bool
 	botCanClean       bool

--- a/controllers/scanner/setup_bot.go
+++ b/controllers/scanner/setup_bot.go
@@ -56,6 +56,7 @@ func (d *Domain) updateChannelInfo(ctx context.Context) error {
 		if channel != nil {
 			channelInfo := d.channels[channelID]
 			channelInfo.title = channel.Title
+			channelInfo.chatType = channel.Type
 			d.channels[channelID] = channelInfo
 
 			if channel.MigratedTo != nil {

--- a/defs.go
+++ b/defs.go
@@ -21,6 +21,31 @@ type ChannelInfo struct {
 	ID         int64
 	MigratedTo *int64
 	Title      string
+	// Type is the Telegram chat type. It is one of the ChatType* constants
+	// (e.g. ChatTypeChannel, ChatTypeSupergroup). An empty value means the type
+	// has not been resolved yet; callers should treat that as "unknown".
+	Type string
+}
+
+// Telegram chat type values, mirroring the "type" field returned by the Bot API
+// getChat method. They let consumers distinguish broadcast channels from chats
+// and groups (relevant for cleanup, which behaves the same but should be
+// reported with the correct noun).
+const (
+	ChatTypePrivate    = "private"
+	ChatTypeGroup      = "group"
+	ChatTypeSupergroup = "supergroup"
+	ChatTypeChannel    = "channel"
+)
+
+// ChatTypeNoun returns a human-readable noun for the given chat type suitable
+// for embedding into user-facing messages (e.g. report headers). Unknown or
+// empty values fall back to "chat".
+func ChatTypeNoun(chatType string) string {
+	if chatType == ChatTypeChannel {
+		return "channel"
+	}
+	return "chat"
 }
 
 type InlineButton struct {

--- a/processors/kicker/process_report.go
+++ b/processors/kicker/process_report.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"
 
+	guard "github.com/MobDev-Hobby/telegram-nda-guard"
 	"github.com/MobDev-Hobby/telegram-nda-guard/processors"
 	"github.com/MobDev-Hobby/telegram-nda-guard/utils"
 )
@@ -74,7 +75,7 @@ func (d *Domain) ProcessReport(
 	}
 
 	message := fmt.Sprintf(
-		"<b>Clean report for chat %s</b>"+
+		"<b>Clean report for %s %s</b>"+
 			"\n\n<b>Users:</b>"+
 			"\n• Good: <b>%d</b>"+
 			"\n• Unknown: <b>%d</b>"+
@@ -84,6 +85,7 @@ func (d *Domain) ProcessReport(
 			"• Keep banned: <b>%t</b>. \n"+
 			"• Clean messages: <b>%t</b>. \n"+
 			"• Clean unknown: <b>%t</b>",
+		guard.ChatTypeNoun(report.Channel.Type),
 		report.Channel.Title,
 		len(report.AllowedUsers),
 		len(report.UnknownUsers),

--- a/processors/reporter/process_report.go
+++ b/processors/reporter/process_report.go
@@ -23,11 +23,12 @@ func (d *Domain) ProcessReport(
 
 	_, err := message.WriteString(
 		fmt.Sprintf(
-			"<b>Scan report for chat %s</b>"+
+			"<b>Scan report for %s %s</b>"+
 				"\n\n<b>Users:</b>"+
 				"\n• Good: <b>%d</b>"+
 				"\n• Unknown: <b>%d</b>"+
 				"\n• Bad: <b>%d</b>\n",
+			guard.ChatTypeNoun(report.Channel.Type),
 			report.Channel.Title,
 			len(report.AllowedUsers),
 			len(report.UnknownUsers),

--- a/telegram/bots/bot/get_chat.go
+++ b/telegram/bots/bot/get_chat.go
@@ -43,5 +43,6 @@ func (d *Domain) GetChat(ctx context.Context, channelID int64) (*guard.ChannelIn
 		ID:         channelID,
 		Title:      chat.Title,
 		MigratedTo: migratedTo,
+		Type:       string(chat.Type),
 	}, nil
 }


### PR DESCRIPTION
Closes beads issue telegram-nda-guard-ehg (GLM-5).

## What
Deep-audit of channel cleanup support: the kicker is **already neutral** to chat/channel (works by ChatID + the `-100` ID logic; `BanChatMember` applies to both channels and supergroups via Bot API). However the domain had no field to distinguish them, and reports hardcoded the noun "chat". This adds the missing metadata and fixes the wording — no behavioral change to banning.

## Changes
- `guard.ChannelInfo.Type string` + `ChatType* ` constants (`private`/`group`/`supergroup`/`channel`).
- `guard.ChatTypeNoun(type)` helper → "channel" for broadcast channels, "chat" otherwise.
- `bots/bot.GetChat` now populates `Type` from `models.ChatType`.
- Scanner caches `chatType` and propagates it into `AccessReport.Channel`.
- `reporter` and `kicker` report headers use the correct noun instead of hardcoded "chat".

## Why
Sets up the domain so future per-type logic (and accurate user-facing reports) is possible. Cleanup of broadcast channels already works; this just stops mislabeling them as "chat".

## Migration
**Additive, non-breaking.** `Type` is a new optional field; existing consumers of `guard.ChannelInfo` are unaffected. Implementations of `TelegramBot.GetChat` should populate `Type` for accurate reporting.

## Validation
- `go build ./...` ✓
- `go vet ./...` ✓
- Pre-existing test failure `storage/session/file TestNew/empty_session` is unrelated (fails on master too).

<!-- reviewed-by: pending codex review -->