### PR TITLE
Isolate kicker from go-telegram/bot + per-channel CleanOptions (glm-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,90 @@
+# Changelog
+
+All notable changes to **telegram-nda-guard** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project aims to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## How this project uses the changelog
+
+`telegram-nda-guard` is a framework: other projects consume its packages
+(`controllers/scanner`, `processors/*`, `storage/*`, `telegram/*`) and implement
+its interfaces. **Any change to a public interface, constructor, functional option,
+or DTO that consumers depend on must be recorded here** so consumers can migrate.
+
+Each release section contains:
+
+- **Added** — new capabilities, new interface methods, new options, new packages.
+- **Changed** — modifications to existing behavior, signatures, or defaults.
+- **Deprecated** — soon-to-be-removed features.
+- **Removed** — deleted capabilities (always breaking).
+- **Fixed** — bug fixes.
+- **Migration** — concrete steps consumers must take when a change is breaking or
+  requires wiring adjustments. If an interface gained a method, `Migration` lists
+  every other implementation (including custom ones) that must add it.
+
+When in doubt, add a `Migration` note. It is cheaper than a silent break.
+
+---
+
+## [Unreleased]
+
+### Added
+
+- `guard.ChannelInfo.Type` (`string`) — the Telegram chat type, plus
+  `ChatType*` constants (`ChatTypePrivate`, `ChatTypeGroup`,
+  `ChatTypeSupergroup`, `ChatTypeChannel`) and a `guard.ChatTypeNoun(type)`
+  helper that returns `"channel"` for broadcast channels and `"chat"`
+  otherwise. This lets consumers distinguish channels from chats/groups.
+  `bots/bot.GetChat` now populates `Type` from the Bot API response, and the
+  scan/clean reports (reporter and kicker) use the correct noun instead of the
+  hardcoded "chat".
+- Established this `CHANGELOG.md` and the migration-note convention documented
+  above. Future interface/contract changes will be recorded under this section
+  until the next tagged release.
+
+### Migration
+
+No action required for consumers at this point. This entry only formalizes the
+changelog going forward.
+
+---
+
+## [0.1.0] — 2024 (full refactoring, no backward compatibility)
+
+### Changed
+
+- **Breaking:** project-wide refactoring. The phone-auth user bot was removed;
+  the user bot now uses the bot account (more secure). The `SessionStorage`
+  contract was changed to match the new userbot version. Existing callers that
+  constructed the previous user bot / session storage need to be updated to the
+  new constructors and options.
+
+### Migration
+
+This release intentionally broke backward compatibility. Consumers must:
+
+1. Update user bot construction to the new bot-account-based flow.
+2. Update `SessionStorage` implementations to the new method contract.
+3. Review `cmd/example/main.go` for the current wiring reference.
+
+> Note: this historical release shipped **without** a migration document at the
+> time. It is recorded here retroactively for completeness.
+
+---
+
+## Conventional locations of the consumer-facing interfaces
+
+The framework's public surface lives in these files. Changes here are the most
+likely to require a `Migration` note:
+
+| Interface / type | File | Purpose |
+|---|---|---|
+| `guard.User`, `guard.ChannelInfo`, `guard.Message`, `guard.InlineButton`, `guard.Permission` | `defs.go` | Core domain DTOs |
+| `scanner.ProtectedChannelStorage`, `scanner.Logger`, `scanner.UserReportProcessor`, `scanner.CheckUserAccess`, `scanner.UserBot`, `scanner.TelegramBot` | `controllers/scanner/dep.go` | Controller-side contracts |
+| `scanner.ProtectedChannel`, `scanner.ChannelInfo` (controller), `scanner.ScanRequest` | `controllers/scanner/defs.go` | Controller domain model |
+| `scanner.ProcessorOption` + `With*` options | `controllers/scanner/options.go` | Controller configuration |
+| `processors.AccessReport` | `processors/defs.go` | Report DTO shared with processors |
+| `kicker.TelegramBotUserKicker`, `kicker.Option` | `processors/kicker/dep.go`, `options.go` | Cleaner processor contract |
+| `reporter.TelegramBotMessageSender`, `reporter.Option` | `processors/reporter/dep.go`, `options.go` | Reporter processor contract |
+| `channels.ProtectedChannel` (storage model) | `storage/channels/defs.go` | Persisted channel model |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ When in doubt, add a `Migration` note. It is cheaper than a silent break.
 
 ### Added
 
+- `processors.CleanOptions` (`KeepBanned`, `CleanMessages`, `CleanUnknown`) and
+  an optional `AccessReport.CleanOptions` field, so cleanup behavior can be
+  configured per-channel instead of only process-wide.
+- `kicker.UserRestrictor` — a transport-agnostic domain interface
+  (`SendReportMessage`, `Ban`, `Unban`) that the kicker consumes. The bundled
+  `telegram/bots/bot.Domain` implements it (`Ban`/`Unban`/`SendReportMessage`),
+  including the Bot API `-100` chat-ID normalization that previously lived
+  inside the kicker.
+- `scanner.ProtectedChannel.CleanOptions` (`*processors.CleanOptions`) —
+  per-channel cleanup overrides forwarded into the cleaner's `AccessReport`.
 - `guard.ChannelInfo.Type` (`string`) — the Telegram chat type, plus
   `ChatType*` constants (`ChatTypePrivate`, `ChatTypeGroup`,
   `ChatTypeSupergroup`, `ChatTypeChannel`) and a `guard.ChatTypeNoun(type)`
@@ -43,10 +53,42 @@ When in doubt, add a `Migration` note. It is cheaper than a silent break.
   above. Future interface/contract changes will be recorded under this section
   until the next tagged release.
 
+### Changed
+
+- **`kicker.New` now takes a `UserRestrictor` instead of `*bot.Bot`.** The
+  kicker no longer imports `github.com/go-telegram/bot`; it operates purely on
+  domain types. Per-channel `CleanOptions` (when present) override the
+  kicker's process-wide defaults.
+- `kicker.TelegramBotUserKicker` is **removed** in favor of `UserRestrictor`.
+
+### Fixed
+
+- `cmd/example/main.go` called `kicker.WithKeepBanned(options.KickUnknownUsers)`
+  twice; the second call should have been `kicker.WithCleanUnknown(...)`, so the
+  "kick unknown users" flag was silently ignored. Fixed.
+
 ### Migration
 
-No action required for consumers at this point. This entry only formalizes the
-changelog going forward.
+- **`kicker.New(restrictor UserRestrictor, opts...)`** — callers that passed
+  `telegramBotDomain.GetBot()` (`*bot.Bot`) must now pass the bot **domain**
+  (`telegramBotDomain`), which implements `UserRestrictor`:
+  ```go
+  // before
+  kicker.New(telegramBotDomain.GetBot(), ...)
+  // after
+  kicker.New(telegramBotDomain, ...)
+  ```
+- Any custom type passed to the kicker must implement the new
+  `UserRestrictor` interface (`SendReportMessage`, `Ban`, `Unban`). The old
+  `TelegramBotUserKicker` interface (`SendMessage`/`BanChatMember`/`UnbanChatMember`
+  with `go-telegram/bot` params) is gone.
+- Optional: to enable per-channel cleanup behavior, set
+  `scanner.ProtectedChannel.CleanOptions`. Otherwise the kicker's configured
+  defaults apply as before.
+
+### Previous (changelog formalization)
+
+No action required for consumers at this point beyond the changes above.
 
 ---
 

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -143,11 +143,11 @@ func main() {
 	)
 
 	cleanReporter := kicker.New(
-		telegramBotDomain.GetBot(),
+		telegramBotDomain,
 		kicker.WithLogger(logger.Named("clean-report-processor")),
 		kicker.WithCleanMessages(options.HideMessagesForKickedUsers),
 		kicker.WithKeepBanned(options.KeepKickedUsersBanned),
-		kicker.WithKeepBanned(options.KickUnknownUsers),
+		kicker.WithCleanUnknown(options.KickUnknownUsers),
 	)
 
 	channels := make([]scanner.ProtectedChannel, 0, len(options.Channels))

--- a/controllers/scanner/channel_users_checker.go
+++ b/controllers/scanner/channel_users_checker.go
@@ -98,6 +98,7 @@ func (d *Domain) ProcessRequest(ctx context.Context, request ScanRequest) {
 		Channel: guard.ChannelInfo{
 			ID:    request.channelInfo.id,
 			Title: request.channelInfo.title,
+			Type:  request.channelInfo.chatType,
 		},
 		AllowedUsers: []guard.User{},
 		DeniedUsers:  []guard.User{},

--- a/controllers/scanner/channel_users_checker.go
+++ b/controllers/scanner/channel_users_checker.go
@@ -103,6 +103,9 @@ func (d *Domain) ProcessRequest(ctx context.Context, request ScanRequest) {
 		AllowedUsers: []guard.User{},
 		DeniedUsers:  []guard.User{},
 		UnknownUsers: []guard.User{},
+		// Forward per-channel clean options so the cleaner can apply them
+		// instead of its process-wide defaults. Nil means "use defaults".
+		CleanOptions: request.cleanOptions,
 	}
 
 	if d.channels[request.channelInfo.id].migratedFrom != nil {
@@ -211,6 +214,7 @@ func (d *Domain) RunUserAccessChecker(ctx context.Context) {
 					channelInfo:     channel,
 					accessChecker:   protectedChannel.AccessChecker,
 					reportProcessor: protectedChannel.CleanReportProcessor,
+					cleanOptions:    protectedChannel.CleanOptions,
 				}
 			}
 		}

--- a/controllers/scanner/defs.go
+++ b/controllers/scanner/defs.go
@@ -5,6 +5,7 @@ type ChannelInfo struct {
 	id                int64
 	commandChannelIDs []int64
 	title             string
+	chatType          string
 	botOnChannel      bool
 	botCanInvite      bool
 	botCanClean       bool

--- a/controllers/scanner/defs.go
+++ b/controllers/scanner/defs.go
@@ -1,5 +1,7 @@
 package scanner
 
+import "github.com/MobDev-Hobby/telegram-nda-guard/processors"
+
 type ChannelInfo struct {
 	migratedFrom      *int64
 	id                int64
@@ -28,6 +30,10 @@ type ProtectedChannel struct {
 	AccessChecker        CheckUserAccess     `json:",omitempty"`
 	ScanReportProcessor  UserReportProcessor `json:",omitempty"`
 	CleanReportProcessor UserReportProcessor `json:",omitempty"`
+	// CleanOptions optionally overrides the cleaner processor's process-wide
+	// defaults for this channel (e.g. keep-banned, clean-messages). When nil,
+	// the processor's own defaults apply. Ignored by scan-only processors.
+	CleanOptions *processors.CleanOptions `json:",omitempty"`
 }
 
 type ScanRequestType int
@@ -46,4 +52,7 @@ type ScanRequest struct {
 	reportChannels  *[]int64
 	accessChecker   CheckUserAccess
 	reportProcessor UserReportProcessor
+	// cleanOptions is forwarded to the cleaner processor via AccessReport so
+	// per-channel cleanup behavior overrides the processor's defaults.
+	cleanOptions *processors.CleanOptions
 }

--- a/controllers/scanner/handler_check.go
+++ b/controllers/scanner/handler_check.go
@@ -145,6 +145,7 @@ func (d *Domain) scanChannelHandler(
 			accessChecker:   protectedChannel.AccessChecker,
 			reportProcessor: reportProcessor,
 			reportChannels:  &[]int64{commandChannelID},
+			cleanOptions:    protectedChannel.CleanOptions,
 		}
 	}
 

--- a/controllers/scanner/setup_bot.go
+++ b/controllers/scanner/setup_bot.go
@@ -56,6 +56,7 @@ func (d *Domain) updateChannelInfo(ctx context.Context) error {
 		if channel != nil {
 			channelInfo := d.channels[channelID]
 			channelInfo.title = channel.Title
+			channelInfo.chatType = channel.Type
 			d.channels[channelID] = channelInfo
 
 			if channel.MigratedTo != nil {

--- a/defs.go
+++ b/defs.go
@@ -21,6 +21,31 @@ type ChannelInfo struct {
 	ID         int64
 	MigratedTo *int64
 	Title      string
+	// Type is the Telegram chat type. It is one of the ChatType* constants
+	// (e.g. ChatTypeChannel, ChatTypeSupergroup). An empty value means the type
+	// has not been resolved yet; callers should treat that as "unknown".
+	Type string
+}
+
+// Telegram chat type values, mirroring the "type" field returned by the Bot API
+// getChat method. They let consumers distinguish broadcast channels from chats
+// and groups (relevant for cleanup, which behaves the same but should be
+// reported with the correct noun).
+const (
+	ChatTypePrivate    = "private"
+	ChatTypeGroup      = "group"
+	ChatTypeSupergroup = "supergroup"
+	ChatTypeChannel    = "channel"
+)
+
+// ChatTypeNoun returns a human-readable noun for the given chat type suitable
+// for embedding into user-facing messages (e.g. report headers). Unknown or
+// empty values fall back to "chat".
+func ChatTypeNoun(chatType string) string {
+	if chatType == ChatTypeChannel {
+		return "channel"
+	}
+	return "chat"
 }
 
 type InlineButton struct {

--- a/processors/defs.go
+++ b/processors/defs.go
@@ -8,4 +8,25 @@ type AccessReport struct {
 	AllowedUsers   []guard.User
 	DeniedUsers    []guard.User
 	UnknownUsers   []guard.User
+	// CleanOptions optionally carries per-channel cleanup behavior for the
+	// cleaner processor (kicker). When nil, the processor falls back to its own
+	// configured defaults. Scan-only processors ignore this field.
+	CleanOptions *CleanOptions
+}
+
+// CleanOptions describes how a channel should be cleaned. It is read by the
+// kicker processor and can be supplied per-channel via AccessReport so that
+// different channels get different cleanup behavior (e.g. one channel keeps
+// users banned, another only kicks).
+type CleanOptions struct {
+	// KeepBanned, when true, leaves banned users banned (no unban follow-up).
+	// When false, the user is unbanned immediately after the ban, i.e. kicked
+	// but able to rejoin.
+	KeepBanned bool
+	// CleanMessages, when true, revokes/deletes the kicked user's recent
+	// messages. Only meaningful together with a ban.
+	CleanMessages bool
+	// CleanUnknown, when true, also kicks users whose access could not be
+	// determined (in addition to denied users).
+	CleanUnknown bool
 }

--- a/processors/kicker/dep.go
+++ b/processors/kicker/dep.go
@@ -2,9 +2,6 @@ package kicker
 
 import (
 	"context"
-
-	"github.com/go-telegram/bot"
-	"github.com/go-telegram/bot/models"
 )
 
 type Logger interface {
@@ -15,17 +12,28 @@ type Logger interface {
 	Debugf(template string, args ...any)
 }
 
-type TelegramBotUserKicker interface {
-	SendMessage(
-		ctx context.Context,
-		params *bot.SendMessageParams,
-	) (*models.Message, error)
-	BanChatMember(
-		ctx context.Context,
-		params *bot.BanChatMemberParams,
-	) (bool, error)
-	UnbanChatMember(
-		ctx context.Context,
-		params *bot.UnbanChatMemberParams,
-	) (bool, error)
+// UserRestrictor is the domain-level contract the kicker uses to act on users.
+// It is intentionally transport-agnostic: implementations translate
+// channelID/userID into the concrete Telegram API calls (including any
+// chat-ID normalization such as the Bot API "-100" prefix).
+//
+// channelID is the same identifier that flows through AccessReport.Channel.ID
+// (the bot-API-style channel identifier). Implementations are responsible for
+// turning it into whatever form their transport expects.
+type UserRestrictor interface {
+	// SendReportMessage delivers a plain HTML text message (e.g. a cleanup
+	// report) to the given chat. It is intentionally separate from a
+	// full-featured SendMessage so processors do not need to construct a full
+	// message DTO just to post a report.
+	SendReportMessage(ctx context.Context, chatID int64, text string) error
+	// Ban restricts userID in channelID. When revokeMessages is true, the
+	// user's recent messages are deleted as part of the restriction.
+	Ban(ctx context.Context, channelID, userID int64, revokeMessages bool) error
+	// Unban lifts a previous restriction on userID in channelID.
+	Unban(ctx context.Context, channelID, userID int64) error
 }
+
+// Compile-time guard: UserRestrictor is a domain interface independent of any
+// concrete transport. Implementations live in the telegram/ packages.
+var _ UserRestrictor = (UserRestrictor)(nil)
+

--- a/processors/kicker/domain.go
+++ b/processors/kicker/domain.go
@@ -5,21 +5,24 @@ import (
 )
 
 type Domain struct {
-	log           Logger
-	botClient     TelegramBotUserKicker
+	log        Logger
+	restrictor UserRestrictor
+	// cleanMessages, keepBanned and cleanUnknown are the process-wide defaults.
+	// They are used when an AccessReport does not carry per-channel
+	// CleanOptions. Per-channel CleanOptions take precedence.
 	cleanMessages bool
 	keepBanned    bool
 	cleanUnknown  bool
 }
 
 func New(
-	botClient TelegramBotUserKicker,
+	restrictor UserRestrictor,
 	opts ...Option,
 ) *Domain {
 
 	d := &Domain{
 		log:           Logger(zap.NewNop().Sugar()),
-		botClient:     botClient,
+		restrictor:    restrictor,
 		keepBanned:    false,
 		cleanMessages: true,
 		cleanUnknown:  false,

--- a/processors/kicker/process_report.go
+++ b/processors/kicker/process_report.go
@@ -3,14 +3,9 @@ package kicker
 import (
 	"context"
 	"fmt"
-	"strconv"
-
-	"github.com/go-telegram/bot"
-	"github.com/go-telegram/bot/models"
 
 	guard "github.com/MobDev-Hobby/telegram-nda-guard"
 	"github.com/MobDev-Hobby/telegram-nda-guard/processors"
-	"github.com/MobDev-Hobby/telegram-nda-guard/utils"
 )
 
 func (d *Domain) ProcessReport(
@@ -18,56 +13,44 @@ func (d *Domain) ProcessReport(
 	report processors.AccessReport,
 ) {
 
+	// Per-channel options override the process-wide defaults when present.
+	keepBanned := d.keepBanned
+	cleanMessages := d.cleanMessages
+	cleanUnknown := d.cleanUnknown
+	if report.CleanOptions != nil {
+		keepBanned = report.CleanOptions.KeepBanned
+		cleanMessages = report.CleanOptions.CleanMessages
+		cleanUnknown = report.CleanOptions.CleanUnknown
+	}
+
 	usersToClean := report.DeniedUsers
 	cleanedUsers := 0
-	if d.cleanUnknown {
+	if cleanUnknown {
 		usersToClean = append(usersToClean, report.UnknownUsers...)
 	}
 
-	commandChatID := report.Channel.ID
-	if commandChatID > 0 {
-		commandChatID, _ = strconv.ParseInt(
-			fmt.Sprintf("-100%d", report.Channel.ID),
-			10,
-			64,
-		)
+	// The channel the user should be restricted in. When a chat migrated to a
+	// supergroup, the new ID is authoritative; the UserRestrictor is then
+	// responsible for any transport-specific normalization of that ID.
+	channelToBan := report.Channel.ID
+	if report.Channel.MigratedTo != nil {
+		channelToBan = *report.Channel.MigratedTo
 	}
 
 	success := true
 	for _, user := range usersToClean {
-		chanToBanUser := commandChatID
-		if report.Channel.MigratedTo != nil {
-			chanToBanUser = *report.Channel.MigratedTo
+		if keepBanned || cleanMessages {
+			if err := d.restrictor.Ban(ctx, channelToBan, user.ID, cleanMessages); err != nil {
+				d.log.Errorf("can't ban user: %s. Error: %s", user.Username, err.Error())
+				success = false
+			}
 		}
 
-		if d.keepBanned || d.cleanMessages {
-			successBanned, err := d.botClient.BanChatMember(
-				ctx,
-				&bot.BanChatMemberParams{
-					ChatID:         chanToBanUser,
-					UserID:         user.ID,
-					RevokeMessages: d.cleanMessages,
-				},
-			)
-			if err != nil {
-				d.log.Errorf("can't send ban user: %s. Error: %s", user.Username, err.Error())
+		if !keepBanned {
+			if err := d.restrictor.Unban(ctx, channelToBan, user.ID); err != nil {
+				d.log.Errorf("can't unban user: %s. Error: %s", user.Username, err.Error())
+				success = false
 			}
-			success = success && successBanned
-		}
-
-		if !d.keepBanned {
-			successKicked, err := d.botClient.UnbanChatMember(
-				ctx,
-				&bot.UnbanChatMemberParams{
-					ChatID:       chanToBanUser,
-					UserID:       user.ID,
-					OnlyIfBanned: false,
-				},
-			)
-			if err != nil {
-				d.log.Errorf("can't send ban user: %s. Error: %s", user.Username, err.Error())
-			}
-			success = success && successKicked
 		}
 		if success {
 			cleanedUsers++
@@ -92,24 +75,13 @@ func (d *Domain) ProcessReport(
 		len(report.DeniedUsers),
 		cleanedUsers,
 		len(usersToClean),
-		d.keepBanned,
-		d.cleanMessages,
-		d.cleanUnknown,
+		keepBanned,
+		cleanMessages,
+		cleanUnknown,
 	)
 
 	for _, chatID := range report.ReportChannels {
-		_, err := d.botClient.SendMessage(
-			ctx,
-			&bot.SendMessageParams{
-				ChatID:    chatID,
-				Text:      message,
-				ParseMode: models.ParseModeHTML,
-				LinkPreviewOptions: &models.LinkPreviewOptions{
-					IsDisabled: utils.Ptr(true),
-				},
-			},
-		)
-		if err != nil {
+		if err := d.restrictor.SendReportMessage(ctx, chatID, message); err != nil {
 			d.log.Errorf("can't send message: %s. Message text: %s", err, message)
 		}
 	}

--- a/processors/kicker/process_report.go
+++ b/processors/kicker/process_report.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"
 
+	guard "github.com/MobDev-Hobby/telegram-nda-guard"
 	"github.com/MobDev-Hobby/telegram-nda-guard/processors"
 	"github.com/MobDev-Hobby/telegram-nda-guard/utils"
 )
@@ -74,7 +75,7 @@ func (d *Domain) ProcessReport(
 	}
 
 	message := fmt.Sprintf(
-		"<b>Clean report for chat %s</b>"+
+		"<b>Clean report for %s %s</b>"+
 			"\n\n<b>Users:</b>"+
 			"\n• Good: <b>%d</b>"+
 			"\n• Unknown: <b>%d</b>"+
@@ -84,6 +85,7 @@ func (d *Domain) ProcessReport(
 			"• Keep banned: <b>%t</b>. \n"+
 			"• Clean messages: <b>%t</b>. \n"+
 			"• Clean unknown: <b>%t</b>",
+		guard.ChatTypeNoun(report.Channel.Type),
 		report.Channel.Title,
 		len(report.AllowedUsers),
 		len(report.UnknownUsers),

--- a/processors/kicker/process_report_test.go
+++ b/processors/kicker/process_report_test.go
@@ -1,0 +1,154 @@
+package kicker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	guard "github.com/MobDev-Hobby/telegram-nda-guard"
+	"github.com/MobDev-Hobby/telegram-nda-guard/processors"
+)
+
+// fakeRestrictor is a recording UserRestrictor used to assert which actions the
+// kicker performed (ban/unban/send). It does not use the generated mock to keep
+// the test focused on the kicker's decision logic, not the mock framework.
+type fakeRestrictor struct {
+	bans     []banCall
+	unbans   []unbanCall
+	sent     []string
+	banErr   error
+	unbanErr error
+}
+
+type banCall struct {
+	channelID, userID int64
+	revoke            bool
+}
+
+type unbanCall struct {
+	channelID, userID int64
+}
+
+func (f *fakeRestrictor) SendReportMessage(_ context.Context, _ int64, text string) error {
+	f.sent = append(f.sent, text)
+	return nil
+}
+func (f *fakeRestrictor) Ban(_ context.Context, channelID, userID int64, revoke bool) error {
+	f.bans = append(f.bans, banCall{channelID, userID, revoke})
+	return f.banErr
+}
+func (f *fakeRestrictor) Unban(_ context.Context, channelID, userID int64) error {
+	f.unbans = append(f.unbans, unbanCall{channelID, userID})
+	return f.unbanErr
+}
+
+func newKickerTestDomain(t *testing.T, restrictor *fakeRestrictor, opts ...Option) *Domain {
+	t.Helper()
+	d := New(restrictor, opts...)
+	return d
+}
+
+func deniedUser(id int64) guard.User {
+	return guard.User{ID: id, Username: "u"}
+}
+
+func TestProcessReport_KicksDeniedUsersByDefault(t *testing.T) {
+	ctx := context.Background()
+	r := &fakeRestrictor{}
+	d := newKickerTestDomain(t, r) // defaults: keepBanned=false, cleanMessages=true, cleanUnknown=false
+
+	d.ProcessReport(ctx, processors.AccessReport{
+		Channel:        guard.ChannelInfo{ID: 100, Title: "Test"},
+		DeniedUsers:    []guard.User{deniedUser(1), deniedUser(2)},
+		ReportChannels: []int64{555},
+	})
+
+	// cleanMessages=true (default) → ban with revoke, then unban (kick).
+	assert.Len(t, r.bans, 2)
+	assert.True(t, r.bans[0].revoke)
+	assert.Len(t, r.unbans, 2)
+	assert.Len(t, r.sent, 1)
+}
+
+func TestProcessReport_KeepBannedSkipsUnban(t *testing.T) {
+	ctx := context.Background()
+	r := &fakeRestrictor{}
+	d := newKickerTestDomain(t, r, WithKeepBanned(true))
+
+	d.ProcessReport(ctx, processors.AccessReport{
+		Channel:        guard.ChannelInfo{ID: 100, Title: "Test"},
+		DeniedUsers:    []guard.User{deniedUser(1)},
+		ReportChannels: []int64{555},
+	})
+
+	assert.Len(t, r.bans, 1)
+	assert.Empty(t, r.unbans, "keepBanned must skip the unban step")
+}
+
+func TestProcessReport_PerChannelCleanOptionsOverrideDefaults(t *testing.T) {
+	ctx := context.Background()
+	r := &fakeRestrictor{}
+	// Process default would clean unknown=false, but the per-channel report
+	// requests cleanUnknown=true AND keepBanned=true.
+	d := newKickerTestDomain(t, r)
+
+	d.ProcessReport(ctx, processors.AccessReport{
+		Channel:     guard.ChannelInfo{ID: 100, Title: "Test"},
+		DeniedUsers: []guard.User{deniedUser(1)},
+		UnknownUsers: []guard.User{deniedUser(2)},
+		CleanOptions: &processors.CleanOptions{
+			KeepBanned:    true,
+			CleanMessages: false,
+			CleanUnknown:  true,
+		},
+		ReportChannels: []int64{555},
+	})
+
+	// cleanUnknown=true → unknown user 2 also banned.
+	assert.Len(t, r.bans, 2, "unknown user must be banned when CleanUnknown")
+	// keepBanned=true → no unbans.
+	assert.Empty(t, r.unbans)
+	// cleanMessages=false → revoke must be false.
+	for _, b := range r.bans {
+		assert.False(t, b.revoke)
+	}
+}
+
+func TestProcessReport_MigratedToUsesNewID(t *testing.T) {
+	ctx := context.Background()
+	r := &fakeRestrictor{}
+	d := newKickerTestDomain(t, r, WithKeepBanned(true))
+
+	migrated := int64(-100999)
+	d.ProcessReport(ctx, processors.AccessReport{
+		Channel: guard.ChannelInfo{
+			ID:         100,
+			Title:      "Test",
+			MigratedTo: &migrated,
+		},
+		DeniedUsers:    []guard.User{deniedUser(1)},
+		ReportChannels: []int64{555},
+	})
+
+	assert.Equal(t, migrated, r.bans[0].channelID, "must restrict in migrated-to chat")
+}
+
+func TestProcessReport_BanErrorDoesNotCountAsCleaned(t *testing.T) {
+	ctx := context.Background()
+	r := &fakeRestrictor{banErr: errors.New("telegran says no")}
+	d := newKickerTestDomain(t, r, WithKeepBanned(true))
+
+	d.ProcessReport(ctx, processors.AccessReport{
+		Channel:        guard.ChannelInfo{ID: 100, Title: "Test"},
+		DeniedUsers:    []guard.User{deniedUser(1)},
+		ReportChannels: []int64{555},
+	})
+
+	// A failed ban must still produce a report message.
+	assert.Len(t, r.sent, 1)
+}
+
+// Compile-time: ensure fakeRestrictor satisfies the interface.
+var _ UserRestrictor = (*fakeRestrictor)(nil)

--- a/processors/reporter/process_report.go
+++ b/processors/reporter/process_report.go
@@ -23,11 +23,12 @@ func (d *Domain) ProcessReport(
 
 	_, err := message.WriteString(
 		fmt.Sprintf(
-			"<b>Scan report for chat %s</b>"+
+			"<b>Scan report for %s %s</b>"+
 				"\n\n<b>Users:</b>"+
 				"\n• Good: <b>%d</b>"+
 				"\n• Unknown: <b>%d</b>"+
 				"\n• Bad: <b>%d</b>\n",
+			guard.ChatTypeNoun(report.Channel.Type),
 			report.Channel.Title,
 			len(report.AllowedUsers),
 			len(report.UnknownUsers),

--- a/telegram/bots/bot/get_chat.go
+++ b/telegram/bots/bot/get_chat.go
@@ -43,5 +43,6 @@ func (d *Domain) GetChat(ctx context.Context, channelID int64) (*guard.ChannelIn
 		ID:         channelID,
 		Title:      chat.Title,
 		MigratedTo: migratedTo,
+		Type:       string(chat.Type),
 	}, nil
 }

--- a/telegram/bots/bot/restrictor.go
+++ b/telegram/bots/bot/restrictor.go
@@ -1,0 +1,73 @@
+package bot
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+
+	"github.com/MobDev-Hobby/telegram-nda-guard/utils"
+)
+
+// normalizeBotChatID converts a bot-API-style channel identifier into the
+// signed "-100..." form expected by the Bot API for supergroups and channels.
+//
+// Telegram Bot API uses negative chat IDs of the form -100<channel_id> for
+// supergroups and broadcast channels. Internally the framework carries the
+// channel id either already in that signed form (negative) or as the raw
+// positive channel id; this helper makes the two interchangeable at the
+// transport boundary so callers can pass whichever form they hold.
+func normalizeBotChatID(channelID int64) int64 {
+	if channelID > 0 {
+		normalized, _ := strconv.ParseInt(fmt.Sprintf("-100%d", channelID), 10, 64)
+		return normalized
+	}
+	return channelID
+}
+
+// SendReportMessage sends an HTML plain-text message to chatID. It is the
+// UserRestrictor counterpart to SendMessage, for processors (e.g. the kicker)
+// that build their own message text and do not need inline/reply keyboards.
+func (d *Domain) SendReportMessage(ctx context.Context, chatID int64, text string) error {
+	_, err := d.botClient.SendMessage(
+		ctx,
+		&bot.SendMessageParams{
+			ChatID:    chatID,
+			Text:      text,
+			ParseMode: models.ParseModeHTML,
+			LinkPreviewOptions: &models.LinkPreviewOptions{
+				IsDisabled: utils.Ptr(true),
+			},
+		},
+	)
+	return err
+}
+
+// Ban restricts userID in channelID. When revokeMessages is true, the user's
+// recent messages are deleted as part of the restriction.
+func (d *Domain) Ban(ctx context.Context, channelID, userID int64, revokeMessages bool) error {
+	_, err := d.botClient.BanChatMember(
+		ctx,
+		&bot.BanChatMemberParams{
+			ChatID:         normalizeBotChatID(channelID),
+			UserID:         userID,
+			RevokeMessages: revokeMessages,
+		},
+	)
+	return err
+}
+
+// Unban lifts a previous restriction on userID in channelID.
+func (d *Domain) Unban(ctx context.Context, channelID, userID int64) error {
+	_, err := d.botClient.UnbanChatMember(
+		ctx,
+		&bot.UnbanChatMemberParams{
+			ChatID:       normalizeBotChatID(channelID),
+			UserID:       userID,
+			OnlyIfBanned: false,
+		},
+	)
+	return err
+}


### PR DESCRIPTION
Closes beads issue telegram-nda-guard-nky (GLM-4).

**Builds on #20 (glm-5 ChatType) — rebased on top of it. Merge #20 first.**

## What
Decouples the cleaner processor () from the concrete  SDK and makes cleanup behavior configurable per-channel.

## Changes
- **New domain interface** `kicker.UserRestrictor` (`SendReportMessage`/`Ban`/`Unban`) — transport-agnostic. The kicker now imports **no** `go-telegram/bot` types.
- `telegram/bots/bot.Domain` implements `UserRestrictor` (`Ban`/`Unban`/`SendReportMessage`); the Bot API `-100` chat-ID normalization that used to live inside the kicker moved here (`normalizeBotChatID`), where it belongs.
- **Per-channel cleanup:** `processors.CleanOptions` + optional `AccessReport.CleanOptions`. `scanner.ProtectedChannel.CleanOptions` flows through `ScanRequest` into the report; per-channel values override the kicker's process-wide defaults.
- `kicker.TelegramBotUserKicker` removed in favor of `UserRestrictor`.
- **Fixed bug:** `cmd/example/main.go` called `WithKeepBanned(options.KickUnknownUsers)` twice instead of `WithCleanUnknown(...)` — the "kick unknown" flag was silently ignored.
- New unit tests for the kicker (5 cases): default kick, keepBanned, per-channel override, migrated-chat ID, error handling.

## Why
- The audit found the kicker hard-bound to `*bot.Bot` types, making it untestable and non-substitutable. Now any transport can implement `UserRestrictor`.
- Per-channel settings are required for the upcoming `/settings` UI (GLM-6).

## Migration
- **Breaking:** `kicker.New(restrictor UserRestrictor, ...)`. Callers passing `telegramBotDomain.GetBot()` must pass the bot domain: `kicker.New(telegramBotDomain, ...)`.
- Custom kicker backends must implement `UserRestrictor` (`SendReportMessage`/`Ban`/`Unban`). Old `TelegramBotUserKicker` is gone.
- Optional: set `scanner.ProtectedChannel.CleanOptions` for per-channel behavior; otherwise kicker defaults apply.

## Validation
- `go build ./...` ✓  `go vet ./...` ✓
- `go test ./processors/kicker/...` ✓ (5/5 new tests pass)
- Pre-existing unrelated failure `session/file TestNew/empty_session` fails on master too.

<!-- reviewed-by: pending codex review -->