### PR TITLE
Add command authorization subsystem: Authorizer + hybrid impl (glm-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,100 @@
+# Changelog
+
+All notable changes to **telegram-nda-guard** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project aims to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## How this project uses the changelog
+
+`telegram-nda-guard` is a framework: other projects consume its packages
+(`controllers/scanner`, `processors/*`, `storage/*`, `telegram/*`) and implement
+its interfaces. **Any change to a public interface, constructor, functional option,
+or DTO that consumers depend on must be recorded here** so consumers can migrate.
+
+Each release section contains:
+
+- **Added** — new capabilities, new interface methods, new options, new packages.
+- **Changed** — modifications to existing behavior, signatures, or defaults.
+- **Deprecated** — soon-to-be-removed features.
+- **Removed** — deleted capabilities (always breaking).
+- **Fixed** — bug fixes.
+- **Migration** — concrete steps consumers must take when a change is breaking or
+  requires wiring adjustments. If an interface gained a method, `Migration` lists
+  every other implementation (including custom ones) that must add it.
+
+When in doubt, add a `Migration` note. It is cheaper than a silent break.
+
+---
+
+## [Unreleased]
+
+### Added
+
+- **Command authorization subsystem.** New `scanner.Authorizer` interface
+  (`Authorize(ctx, *guard.Update) (bool, error)`) and a `scanner.WithAuthorizer`
+  option. The bundled default lives in `controllers/scanner/authorizer` as
+  `HybridAuthorizer`, which allows the configured owner, an explicit allowlist,
+  and (optionally) administrators of the originating chat.
+- `scanner.TelegramBot.GetChatAdministrators(ctx, chatID) ([]int64, error)` —
+  implemented by `telegram/bots/bot.Domain`, used by the hybrid authorizer's
+  admin check.
+- `REQUIRE_ADMIN_AUTH` env var in `cmd/example` to opt into owner+admin
+  authorization (off by default for backwards compatibility).
+- Established this `CHANGELOG.md` and the migration-note convention documented
+  above. Future interface/contract changes will be recorded under this section
+  until the next tagged release.
+
+### Security
+
+- Previously **any member of a controlling chat** could run `/scan`, `/clean`,
+  `/list`, `/add` and similar commands — there was no authorization at all. The
+  new `Authorizer` is a pluggable chokepoint; protected commands now go through
+  `Domain.requireAuth`. The default remains allow-all unless an authorizer is
+  configured, so existing deployments keep working.
+
+### Migration
+
+No action required for consumers at this point. This entry only formalizes the
+changelog going forward.
+
+---
+
+## [0.1.0] — 2024 (full refactoring, no backward compatibility)
+
+### Changed
+
+- **Breaking:** project-wide refactoring. The phone-auth user bot was removed;
+  the user bot now uses the bot account (more secure). The `SessionStorage`
+  contract was changed to match the new userbot version. Existing callers that
+  constructed the previous user bot / session storage need to be updated to the
+  new constructors and options.
+
+### Migration
+
+This release intentionally broke backward compatibility. Consumers must:
+
+1. Update user bot construction to the new bot-account-based flow.
+2. Update `SessionStorage` implementations to the new method contract.
+3. Review `cmd/example/main.go` for the current wiring reference.
+
+> Note: this historical release shipped **without** a migration document at the
+> time. It is recorded here retroactively for completeness.
+
+---
+
+## Conventional locations of the consumer-facing interfaces
+
+The framework's public surface lives in these files. Changes here are the most
+likely to require a `Migration` note:
+
+| Interface / type | File | Purpose |
+|---|---|---|
+| `guard.User`, `guard.ChannelInfo`, `guard.Message`, `guard.InlineButton`, `guard.Permission` | `defs.go` | Core domain DTOs |
+| `scanner.ProtectedChannelStorage`, `scanner.Logger`, `scanner.UserReportProcessor`, `scanner.CheckUserAccess`, `scanner.UserBot`, `scanner.TelegramBot` | `controllers/scanner/dep.go` | Controller-side contracts |
+| `scanner.ProtectedChannel`, `scanner.ChannelInfo` (controller), `scanner.ScanRequest` | `controllers/scanner/defs.go` | Controller domain model |
+| `scanner.ProcessorOption` + `With*` options | `controllers/scanner/options.go` | Controller configuration |
+| `processors.AccessReport` | `processors/defs.go` | Report DTO shared with processors |
+| `kicker.TelegramBotUserKicker`, `kicker.Option` | `processors/kicker/dep.go`, `options.go` | Cleaner processor contract |
+| `reporter.TelegramBotMessageSender`, `reporter.Option` | `processors/reporter/dep.go`, `options.go` | Reporter processor contract |
+| `channels.ProtectedChannel` (storage model) | `storage/channels/defs.go` | Persisted channel model |

--- a/cmd/example/env_vars.go
+++ b/cmd/example/env_vars.go
@@ -21,4 +21,8 @@ type environmentConfig struct {
 	KickUnknownUsers           bool            `env:"KICK_UNKNOWN_USERS"`
 	UseRedisSessionStorage     bool            `env:"USE_REDIS_SESSION_STORAGE"`
 	RedisHost                  string          `env:"REDIS_HOST"`
+	// RequireAdminAuth, when true, restricts bot commands to the owner and to
+	// administrators of the controlling chat. When false (default), commands
+	// remain open to all members (backwards-compatible).
+	RequireAdminAuth bool `env:"REQUIRE_ADMIN_AUTH"`
 }

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -15,6 +15,7 @@ import (
 	cachedchecker "github.com/MobDev-Hobby/telegram-nda-guard/checker/cached"
 	demochecker "github.com/MobDev-Hobby/telegram-nda-guard/checker/demo"
 	"github.com/MobDev-Hobby/telegram-nda-guard/controllers/scanner"
+	"github.com/MobDev-Hobby/telegram-nda-guard/controllers/scanner/authorizer"
 	"github.com/MobDev-Hobby/telegram-nda-guard/processors/kicker"
 	"github.com/MobDev-Hobby/telegram-nda-guard/processors/reporter"
 	redischanstorage "github.com/MobDev-Hobby/telegram-nda-guard/storage/channels/redis"
@@ -176,6 +177,22 @@ func main() {
 		scanner.WithDefaultScanProcessor(scanReporter),
 		scanner.WithDefaultCleanProcessor(cleanReporter),
 		scanner.WithDefaultAccessChecker(cachedAccessChecker),
+	}
+
+	// Authorization: when requested, restrict commands to the owner and to the
+	// administrators of the controlling chat. Otherwise commands stay open to
+	// all members (backwards-compatible default).
+	if options.RequireAdminAuth {
+		authorizerOpts := []authorizer.Option{
+			authorizer.WithOwner(options.AdminChatID),
+			authorizer.WithRequireAdmin(),
+			authorizer.WithLogger(logger.Named("authorizer")),
+		}
+		controllerOptions = append(
+			controllerOptions,
+			scanner.WithAuthorizer(authorizer.New(telegramBotDomain, authorizerOpts...)),
+		)
+		logger.Infof("Command authorization enabled (owner + chat admins)")
 	}
 
 	if redisClient != nil {

--- a/controllers/scanner/authorization.go
+++ b/controllers/scanner/authorization.go
@@ -1,0 +1,55 @@
+package scanner
+
+import (
+	"context"
+
+	guard "github.com/MobDev-Hobby/telegram-nda-guard"
+)
+
+// allowAllAuthorizer permits every update. It is the default when no
+// Authorizer is configured, preserving the pre-authorization behavior where any
+// member of a controlling chat could run commands. Operators who want to
+// restrict access should pass a real Authorizer via WithAuthorizer.
+type allowAllAuthorizer struct{}
+
+func (allowAllAuthorizer) Authorize(_ context.Context, _ *guard.Update) (bool, error) {
+	return true, nil
+}
+
+// authorizer returns the configured Authorizer, falling back to an allow-all
+// implementation when none was set. This keeps Run() backwards-compatible.
+func (d *Domain) resolvedAuthorizer() Authorizer {
+	if d.authorizer != nil {
+		return d.authorizer
+	}
+	return allowAllAuthorizer{}
+}
+
+// authorize checks whether the sender of update may run a protected command.
+// Returns true when authorized (or when authorization is not enforced). On a
+// denial it logs at debug level so operators can see why a command was ignored.
+func (d *Domain) authorize(ctx context.Context, update *guard.Update) bool {
+	ok, err := d.resolvedAuthorizer().Authorize(ctx, update)
+	if err != nil {
+		d.log.Errorf("authorize denied command: %s", err)
+		return false
+	}
+	if !ok {
+		d.log.Debugf("authorize denied command from update")
+	}
+	return ok
+}
+
+// requireAuth wraps a command callback so that it only runs when the sender is
+// authorized. It is the single chokepoint used when registering handlers, so
+// every protected command goes through authorization uniformly.
+func (d *Domain) requireAuth(
+	callback func(ctx context.Context, update *guard.Update),
+) func(ctx context.Context, update *guard.Update) {
+	return func(ctx context.Context, update *guard.Update) {
+		if !d.authorize(ctx, update) {
+			return
+		}
+		callback(ctx, update)
+	}
+}

--- a/controllers/scanner/authorizer/hybrid.go
+++ b/controllers/scanner/authorizer/hybrid.go
@@ -1,0 +1,138 @@
+// Package authorizer provides a default (hybrid) implementation of
+// scanner.Authorizer. It is kept in its own package so the controller does not
+// depend on a concrete authorization strategy and consumers can substitute
+// their own (e.g. an SSO/JWT-backed authorizer) via scanner.WithAuthorizer.
+package authorizer
+
+import (
+	"context"
+	"errors"
+
+	guard "github.com/MobDev-Hobby/telegram-nda-guard"
+)
+
+// ChatAdminLister returns the user IDs of the administrators (owner + admins)
+// of the given chat. The bundled telegram/bots/bot.Domain satisfies this.
+type ChatAdminLister interface {
+	GetChatAdministrators(ctx context.Context, chatID int64) ([]int64, error)
+}
+
+// Logger mirrors the project-wide logger contract (intentionally duplicated
+// per-package rather than shared, matching the rest of the codebase).
+type Logger interface {
+	Errorf(template string, args ...any)
+	Debugf(template string, args ...any)
+}
+
+// HybridAuthorizer allows a command when ANY of the following holds:
+//
+//   - the sender's user ID is in the explicit allowlist;
+//   - the sender's user ID is the configured owner;
+//   - the sender is an administrator of the chat the command originated from
+//     (only when RequireAdmin is true).
+//
+// When RequireAdmin is false and neither the allowlist nor owner matches, the
+// command is denied. This keeps authorization explicit and auditable.
+//
+// The allowlist and owner are checked first (cheap, no I/O); the admin check is
+// performed last because it issues a Telegram API call.
+type HybridAuthorizer struct {
+	bot           ChatAdminLister
+	ownerUserID   int64
+	allowUserIDs  []int64
+	requireAdmin  bool
+	log           Logger
+}
+
+// Option configures a HybridAuthorizer.
+type Option func(*HybridAuthorizer)
+
+// WithOwner sets the owner user ID that is always allowed.
+func WithOwner(ownerUserID int64) Option {
+	return func(h *HybridAuthorizer) {
+		h.ownerUserID = ownerUserID
+	}
+}
+
+// WithAllowlist adds explicit allowed user IDs in addition to the owner.
+func WithAllowlist(userIDs []int64) Option {
+	return func(h *HybridAuthorizer) {
+		h.allowUserIDs = append(h.allowUserIDs, userIDs...)
+	}
+}
+
+// WithRequireAdmin enables the "administrator of the originating chat" check.
+// When enabled, a sender who is an admin of the chat the command came from is
+// also allowed. Without it, only the owner and allowlist are honored.
+func WithRequireAdmin() Option {
+	return func(h *HybridAuthorizer) {
+		h.requireAdmin = true
+	}
+}
+
+// WithLogger injects a logger. Optional; a no-op logger is used by default.
+func WithLogger(log Logger) Option {
+	return func(h *HybridAuthorizer) {
+		h.log = log
+	}
+}
+
+// noopLogger discards all output.
+type noopLogger struct{}
+
+func (noopLogger) Errorf(string, ...any) {}
+func (noopLogger) Debugf(string, ...any) {}
+
+// New creates a HybridAuthorizer backed by bot. Pass functional options to
+// configure owner, allowlist and admin enforcement.
+func New(bot ChatAdminLister, opts ...Option) *HybridAuthorizer {
+	h := &HybridAuthorizer{
+		bot: bot,
+		log: noopLogger{},
+	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
+}
+
+// Authorize implements scanner.Authorizer.
+func (h *HybridAuthorizer) Authorize(ctx context.Context, update *guard.Update) (bool, error) {
+	if update == nil || update.Message == nil {
+		// Callbacks carry the originating message; authorize on that.
+		if update != nil && update.CallbackQuery != nil && update.CallbackQuery.Message != nil {
+			return h.authorizeMessage(ctx, update.CallbackQuery.Message)
+		}
+		return false, errors.New("authorize: update has no message")
+	}
+	return h.authorizeMessage(ctx, update.Message)
+}
+
+func (h *HybridAuthorizer) authorizeMessage(ctx context.Context, msg *guard.MessageReceived) (bool, error) {
+	senderID := msg.User.ID
+
+	// 1. Owner always wins.
+	if h.ownerUserID != 0 && senderID == h.ownerUserID {
+		return true, nil
+	}
+	// 2. Explicit allowlist.
+	for _, id := range h.allowUserIDs {
+		if id == senderID {
+			return true, nil
+		}
+	}
+	// 3. Optional: sender is an admin of the originating chat.
+	if h.requireAdmin {
+		admins, err := h.bot.GetChatAdministrators(ctx, msg.ChatID)
+		if err != nil {
+			h.log.Errorf("authorize: can't get chat admins for %d: %s", msg.ChatID, err)
+			return false, nil
+		}
+		for _, id := range admins {
+			if id == senderID {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/controllers/scanner/authorizer/hybrid_test.go
+++ b/controllers/scanner/authorizer/hybrid_test.go
@@ -1,0 +1,122 @@
+package authorizer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	guard "github.com/MobDev-Hobby/telegram-nda-guard"
+)
+
+// stubAdminLister is a controllable ChatAdminLister.
+type stubAdminLister struct {
+	admins []int64
+	err    error
+	calls  int
+}
+
+func (s *stubAdminLister) GetChatAdministrators(_ context.Context, _ int64) ([]int64, error) {
+	s.calls++
+	return s.admins, s.err
+}
+
+func msgUpdate(chatID, userID int64) *guard.Update {
+	return &guard.Update{
+		Message: &guard.MessageReceived{
+			Message: guard.Message{ChatID: chatID},
+			User:    guard.User{ID: userID},
+		},
+	}
+}
+
+func callbackUpdate(chatID, userID int64) *guard.Update {
+	return &guard.Update{
+		CallbackQuery: &guard.CallbackQuery{
+			Data: "/scan 1",
+			Message: &guard.MessageReceived{
+				Message: guard.Message{ChatID: chatID},
+				User:    guard.User{ID: userID},
+			},
+		},
+	}
+}
+
+func TestAuthorize_OwnerAlwaysAllowed(t *testing.T) {
+	a := New(&stubAdminLister{}, WithOwner(42))
+	ok, err := a.Authorize(context.Background(), msgUpdate(1, 42))
+	assert.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestAuthorize_Allowlist(t *testing.T) {
+	a := New(&stubAdminLister{}, WithAllowlist([]int64{7, 8}))
+	ok, err := a.Authorize(context.Background(), msgUpdate(1, 8))
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = a.Authorize(context.Background(), msgUpdate(1, 99))
+	assert.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestAuthorize_AdminCheck(t *testing.T) {
+	lst := &stubAdminLister{admins: []int64{100, 101}}
+	a := New(lst, WithRequireAdmin())
+
+	ok, err := a.Authorize(context.Background(), msgUpdate(5, 101))
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, 1, lst.calls, "admin list should be fetched once")
+}
+
+func TestAuthorize_AdminCheckDeniesNonAdmin(t *testing.T) {
+	lst := &stubAdminLister{admins: []int64{100}}
+	a := New(lst, WithRequireAdmin())
+
+	ok, err := a.Authorize(context.Background(), msgUpdate(5, 999))
+	assert.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestAuthorize_AdminErrorDeniesWithoutPropagating(t *testing.T) {
+	lst := &stubAdminLister{err: errors.New("telegram down")}
+	a := New(lst, WithRequireAdmin())
+
+	ok, err := a.Authorize(context.Background(), msgUpdate(5, 100))
+	// An admin-listing failure must deny (fail-closed) but not error out.
+	assert.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestAuthorize_NoConfigDeniesAll(t *testing.T) {
+	a := New(&stubAdminLister{})
+	ok, err := a.Authorize(context.Background(), msgUpdate(1, 1))
+	assert.NoError(t, err)
+	assert.False(t, ok, "with no owner/allowlist/admin, everything is denied")
+}
+
+func TestAuthorize_CallbackUsesMessageSender(t *testing.T) {
+	a := New(&stubAdminLister{}, WithOwner(42))
+	ok, err := a.Authorize(context.Background(), callbackUpdate(1, 42))
+	assert.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestAuthorize_OwnerShortCircuitsAdminCheck(t *testing.T) {
+	lst := &stubAdminLister{}
+	a := New(lst, WithOwner(42), WithRequireAdmin())
+
+	ok, err := a.Authorize(context.Background(), msgUpdate(5, 42))
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, 0, lst.calls, "owner must short-circuit before the admin API call")
+}
+
+func TestAuthorize_NilUpdateDenied(t *testing.T) {
+	a := New(&stubAdminLister{}, WithOwner(42))
+	ok, err := a.Authorize(context.Background(), nil)
+	assert.Error(t, err)
+	assert.False(t, ok)
+}

--- a/controllers/scanner/commands.go
+++ b/controllers/scanner/commands.go
@@ -62,60 +62,60 @@ func (d *Domain) setupCommands(ctx context.Context) {
 			}
 			return false
 		},
-		d.checkChannelHandler,
+		d.requireAuth(d.checkChannelHandler),
 	)
-	d.telegramBot.RegisterHandler(
-		ctx,
-		func(update *guard.Update) bool {
-			if update.CallbackQuery != nil && update.CallbackQuery.Message != nil &&
-				strings.HasPrefix(update.CallbackQuery.Data, "/scan") {
+		d.telegramBot.RegisterHandler(
+			ctx,
+			func(update *guard.Update) bool {
+				if update.CallbackQuery != nil && update.CallbackQuery.Message != nil &&
+					strings.HasPrefix(update.CallbackQuery.Data, "/scan") {
 
-				return true
-			}
-			return false
-		},
-		d.processScanCallbackHandler,
-	)
+					return true
+				}
+				return false
+			},
+			d.requireAuth(d.processScanCallbackHandler),
+		)
 
-	d.log.Debugf("Register /clean handler")
-	d.telegramBot.RegisterHandler(
-		ctx,
-		func(update *guard.Update) bool {
-			if update.Message != nil &&
-				strings.HasPrefix(update.Message.Text, "/clean") {
+		d.log.Debugf("Register /clean handler")
+		d.telegramBot.RegisterHandler(
+			ctx,
+			func(update *guard.Update) bool {
+				if update.Message != nil &&
+					strings.HasPrefix(update.Message.Text, "/clean") {
 
-				return true
-			}
-			return false
-		},
-		d.cleanChannelHandler,
-	)
-	d.telegramBot.RegisterHandler(
-		ctx,
-		func(update *guard.Update) bool {
-			if update.CallbackQuery != nil && update.CallbackQuery.Message != nil &&
-				strings.HasPrefix(update.CallbackQuery.Data, "/clean") {
+					return true
+				}
+				return false
+			},
+			d.requireAuth(d.cleanChannelHandler),
+		)
+		d.telegramBot.RegisterHandler(
+			ctx,
+			func(update *guard.Update) bool {
+				if update.CallbackQuery != nil && update.CallbackQuery.Message != nil &&
+					strings.HasPrefix(update.CallbackQuery.Data, "/clean") {
 
-				return true
-			}
-			return false
-		},
-		d.processCleanCallbackHandler,
-	)
+					return true
+				}
+				return false
+			},
+			d.requireAuth(d.processCleanCallbackHandler),
+		)
 
-	d.log.Debugf("Register /list handler")
-	d.telegramBot.RegisterHandler(
-		ctx,
-		func(update *guard.Update) bool {
-			if update.Message != nil &&
-				strings.HasPrefix(update.Message.Text, "/list") {
+		d.log.Debugf("Register /list handler")
+		d.telegramBot.RegisterHandler(
+			ctx,
+			func(update *guard.Update) bool {
+				if update.Message != nil &&
+					strings.HasPrefix(update.Message.Text, "/list") {
 
-				return true
-			}
-			return false
-		},
-		d.ListChannelsHandler,
-	)
+					return true
+				}
+				return false
+			},
+			d.requireAuth(d.ListChannelsHandler),
+		)
 
 	if d.defaultCleanProcessor != nil && d.defaultAccessChecker != nil {
 		d.log.Debugf("Register /add handler")
@@ -129,7 +129,7 @@ func (d *Domain) setupCommands(ctx context.Context) {
 				}
 				return false
 			},
-			d.AddChannelHandler,
+			d.requireAuth(d.AddChannelHandler),
 		)
 		d.telegramBot.RegisterHandler(
 			ctx,

--- a/controllers/scanner/dep.go
+++ b/controllers/scanner/dep.go
@@ -29,6 +29,17 @@ type CheckUserAccess interface {
 	HasAccess(context.Context, *guard.User) (bool, error)
 }
 
+// Authorizer decides whether the sender of an update is allowed to run a
+// protected command. Implementations are pluggable via WithAuthorizer; the
+// bundled default is a hybrid authorizer (see NewHybridAuthorizer) that allows
+// the configured owner and, optionally, administrators of the controlling chat.
+//
+// When Authorize returns (false, nil) the command is silently skipped. A
+// non-nil error also denies the command and is logged.
+type Authorizer interface {
+	Authorize(ctx context.Context, update *guard.Update) (bool, error)
+}
+
 type UserBot interface {
 	Run(
 		ctx context.Context,
@@ -64,5 +75,9 @@ type TelegramBot interface {
 		bool,
 		error,
 	)
+	// GetChatAdministrators returns the user IDs of the administrators of chatID
+	// (owner and admins). Used by the default authorizer to decide whether the
+	// sender of a command may run it.
+	GetChatAdministrators(ctx context.Context, chatID int64) ([]int64, error)
 	CallbackResponse(ctx context.Context, response guard.CallbackResponse)
 }

--- a/controllers/scanner/domain.go
+++ b/controllers/scanner/domain.go
@@ -13,6 +13,7 @@ type Domain struct {
 	userBot     UserBot
 	log         Logger
 	storage     ProtectedChannelStorage
+	authorizer  Authorizer
 
 	adminUserChatID        int64
 	setAdminHash           *string

--- a/controllers/scanner/options.go
+++ b/controllers/scanner/options.go
@@ -123,3 +123,17 @@ func WithStorage(storage ProtectedChannelStorage) func(*Domain) {
 		d.storage = storage
 	}
 }
+
+// WithAuthorizer injects a command authorization strategy. When not provided,
+// the controller uses an allow-all authorizer (backwards-compatible with the
+// pre-authorization behavior, where any member of a controlling chat could run
+// commands). Passing a custom Authorizer (e.g. the bundled HybridAuthorizer)
+// restricts who can run protected commands. See NewHybridAuthorizer.
+func WithAuthorizer(authorizer Authorizer) func(*Domain) {
+	if authorizer == nil {
+		panic("authorizer is nil")
+	}
+	return func(d *Domain) {
+		d.authorizer = authorizer
+	}
+}

--- a/telegram/bots/bot/get_chat_administrators.go
+++ b/telegram/bots/bot/get_chat_administrators.go
@@ -1,0 +1,54 @@
+package bot
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+)
+
+// GetChatAdministrators returns the user IDs of the owner and administrators of
+// chatID. It maps the Bot API GetChatAdministrators response (a discriminated
+// union of ChatMember sub-types) to a flat list of user IDs suitable for
+// membership checks (e.g. by the default authorizer).
+func (d *Domain) GetChatAdministrators(ctx context.Context, chatID int64) ([]int64, error) {
+	members, err := d.botClient.GetChatAdministrators(
+		ctx,
+		&bot.GetChatAdministratorsParams{
+			ChatID: chatID,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get chat administrators: %w", err)
+	}
+
+	ids := make([]int64, 0, len(members))
+	for _, m := range members {
+		if id := chatMemberUserID(m); id != 0 {
+			ids = append(ids, id)
+		}
+	}
+	return ids, nil
+}
+
+// chatMemberUserID extracts the user ID from any ChatMember variant. The Bot API
+// models.ChatMember is a discriminated union; each variant carries the user in a
+// different sub-struct. Returns 0 when the variant or its user is absent.
+func chatMemberUserID(m models.ChatMember) int64 {
+	switch {
+	case m.Owner != nil && m.Owner.User != nil:
+		return m.Owner.User.ID
+	case m.Administrator != nil:
+		return m.Administrator.User.ID
+	case m.Member != nil && m.Member.User != nil:
+		return m.Member.User.ID
+	case m.Restricted != nil && m.Restricted.User != nil:
+		return m.Restricted.User.ID
+	case m.Left != nil && m.Left.User != nil:
+		return m.Left.User.ID
+	case m.Banned != nil && m.Banned.User != nil:
+		return m.Banned.User.ID
+	}
+	return 0
+}


### PR DESCRIPTION
Closes beads issue telegram-nda-guard-7j7 (GLM-3).

## What
Introduces a pluggable command authorization layer. Previously **any member of a controlling chat** could run `/scan`, `/clean`, `/list`, `/add`, etc. — there was no authorization at all.

## Changes
- **New interface** `scanner.Authorizer` (`Authorize(ctx, *guard.Update) (bool, error)`) + `scanner.WithAuthorizer` option.
- **Hybrid default impl** `controllers/scanner/authorizer.HybridAuthorizer`: allows the configured owner, an explicit allowlist, and (optionally) admins of the originating chat. Owner/allowlist are checked before the (I/O) admin check.
- **New bot method** `scanner.TelegramBot.GetChatAdministrators(ctx, chatID)`, implemented by `telegram/bots/bot.Domain` (handles the discriminated-union `models.ChatMember`).
- **Integration:** `Domain.requireAuth` wraps every protected command callback in `setupCommands`; `/id`, `/start`, `/help`, `/retry`, `/admin` stay open (informational/bootstrap).
- **Backwards-compatible default:** when no authorizer is configured, an allow-all authorizer is used — existing deployments keep working.
- `REQUIRE_ADMIN_AUTH` env var in `cmd/example` opts into owner+admin authorization.
- 9 unit tests for the authorizer (owner, allowlist, admin allow/deny, admin-error fail-closed, callback auth, short-circuit, nil update).

## Why
Authorization was a critical gap flagged in the design audit. This makes it pluggable (SSO/JWT/custom) while shipping a sensible default.

## Migration
- **Breaking for custom `scanner.TelegramBot` implementations:** add `GetChatAdministrators(ctx, chatID) ([]int64, error)`. The bundled `bots/bot.Domain` provides it.
- **Optional, non-breaking:** pass `scanner.WithAuthorizer(...)` to restrict commands. Without it, behavior is unchanged.
- `Authorizer` is a single-method interface — trivially substitutable.

## Validation
- `go build ./...` / `go vet ./...` ✓
- `go test ./controllers/scanner/authorizer/...` ✓ (9/9)
- Pre-existing unrelated failure `session/file TestNew/empty_session` fails on master too.

<!-- reviewed-by: pending codex review -->