### PR TITLE
Channel users view command (glm-7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+All notable changes to **telegram-nda-guard** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project aims to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## How this project uses the changelog
+
+`telegram-nda-guard` is a framework: other projects consume its packages
+(`controllers/scanner`, `processors/*`, `storage/*`, `telegram/*`) and implement
+its interfaces. **Any change to a public interface, constructor, functional option,
+or DTO that consumers depend on must be recorded here** so consumers can migrate.
+
+Each release section contains:
+
+- **Added** — new capabilities, new interface methods, new options, new packages.
+- **Changed** — modifications to existing behavior, signatures, or defaults.
+- **Deprecated** — soon-to-be-removed features.
+- **Removed** — deleted capabilities (always breaking).
+- **Fixed** — bug fixes.
+- **Migration** — concrete steps consumers must take when a change is breaking or
+  requires wiring adjustments. If an interface gained a method, `Migration` lists
+  every other implementation (including custom ones) that must add it.
+
+When in doubt, add a `Migration` note. It is cheaper than a silent break.
+
+---
+
+## [Unreleased]
+
+### Added
+
+- **Channel users view.** New `/users <id>` command (message and inline-button
+  callback) that lists a channel's members, classified into Good / Unknown / Bad
+  by the channel's access checker — a read-only on-demand counterpart to
+  `/scan`. Large listings are truncated per-section with a hint to run `/scan`
+  for a full persisted report. `/list` now shows a `/users` button per channel.
+- Established this `CHANGELOG.md` and the migration-note convention documented
+  above. Future interface/contract changes will be recorded under this section
+  until the next tagged release.
+
+### Migration
+
+No action required for consumers at this point. This entry only formalizes the
+changelog going forward.
+
+---
+
+## [0.1.0] — 2024 (full refactoring, no backward compatibility)
+
+### Changed
+
+- **Breaking:** project-wide refactoring. The phone-auth user bot was removed;
+  the user bot now uses the bot account (more secure). The `SessionStorage`
+  contract was changed to match the new userbot version. Existing callers that
+  constructed the previous user bot / session storage need to be updated to the
+  new constructors and options.
+
+### Migration
+
+This release intentionally broke backward compatibility. Consumers must:
+
+1. Update user bot construction to the new bot-account-based flow.
+2. Update `SessionStorage` implementations to the new method contract.
+3. Review `cmd/example/main.go` for the current wiring reference.
+
+> Note: this historical release shipped **without** a migration document at the
+> time. It is recorded here retroactively for completeness.
+
+---
+
+## Conventional locations of the consumer-facing interfaces
+
+The framework's public surface lives in these files. Changes here are the most
+likely to require a `Migration` note:
+
+| Interface / type | File | Purpose |
+|---|---|---|
+| `guard.User`, `guard.ChannelInfo`, `guard.Message`, `guard.InlineButton`, `guard.Permission` | `defs.go` | Core domain DTOs |
+| `scanner.ProtectedChannelStorage`, `scanner.Logger`, `scanner.UserReportProcessor`, `scanner.CheckUserAccess`, `scanner.UserBot`, `scanner.TelegramBot` | `controllers/scanner/dep.go` | Controller-side contracts |
+| `scanner.ProtectedChannel`, `scanner.ChannelInfo` (controller), `scanner.ScanRequest` | `controllers/scanner/defs.go` | Controller domain model |
+| `scanner.ProcessorOption` + `With*` options | `controllers/scanner/options.go` | Controller configuration |
+| `processors.AccessReport` | `processors/defs.go` | Report DTO shared with processors |
+| `kicker.TelegramBotUserKicker`, `kicker.Option` | `processors/kicker/dep.go`, `options.go` | Cleaner processor contract |
+| `reporter.TelegramBotMessageSender`, `reporter.Option` | `processors/reporter/dep.go`, `options.go` | Reporter processor contract |
+| `channels.ProtectedChannel` (storage model) | `storage/channels/defs.go` | Persisted channel model |

--- a/controllers/scanner/commands.go
+++ b/controllers/scanner/commands.go
@@ -117,6 +117,32 @@ func (d *Domain) setupCommands(ctx context.Context) {
 		d.ListChannelsHandler,
 	)
 
+	d.log.Debugf("Register /users handlers")
+	d.telegramBot.RegisterHandler(
+		ctx,
+		func(update *guard.Update) bool {
+			if update.Message != nil &&
+				strings.HasPrefix(update.Message.Text, "/users") {
+
+				return true
+			}
+			return false
+		},
+		d.UsersHandler,
+	)
+	d.telegramBot.RegisterHandler(
+		ctx,
+		func(update *guard.Update) bool {
+			if update.CallbackQuery != nil && update.CallbackQuery.Message != nil &&
+				strings.HasPrefix(update.CallbackQuery.Data, "/users") {
+
+				return true
+			}
+			return false
+		},
+		d.UsersHandler,
+	)
+
 	if d.defaultCleanProcessor != nil && d.defaultAccessChecker != nil {
 		d.log.Debugf("Register /add handler")
 		d.telegramBot.RegisterHandler(

--- a/controllers/scanner/handler_list.go
+++ b/controllers/scanner/handler_list.go
@@ -81,6 +81,14 @@ func (d *Domain) ListChannelsHandler(
 					},
 				)
 			}
+
+			buttons = append(
+				buttons,
+				guard.InlineButton{
+					Text:    "/users",
+					Command: fmt.Sprintf("/users %d", channelID),
+				},
+			)
 		}
 
 		err = d.telegramBot.SendMessage(

--- a/controllers/scanner/handler_users.go
+++ b/controllers/scanner/handler_users.go
@@ -1,0 +1,223 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	guard "github.com/MobDev-Hobby/telegram-nda-guard"
+)
+
+// UsersHandler lists the members of a channel, split into Good/Unknown/Bad by
+// the channel's access checker. It is the read-only counterpart to /scan: same
+// data gathering, but rendered on demand and without invoking the report or
+// cleaner processors.
+//
+// Triggered by the "/users <id>" message command and the /users <id> inline
+// button (callback). For large channels the listing is truncated with a hint to
+// run /scan for a full persisted report, since Telegram limits member listings.
+func (d *Domain) UsersHandler(
+	ctx context.Context,
+	update *guard.Update,
+) {
+	commandChatID, channelID, ok := d.resolveUsersTarget(update)
+	if !ok {
+		return
+	}
+
+	rendering, err := d.renderChannelUsers(ctx, channelID)
+	if err != nil {
+		_ = d.telegramBot.SendMessage(
+			ctx, &guard.Message{
+				ChatID:   commandChatID,
+				ThreadID: threadIDOf(update),
+				Text:     fmt.Sprintf("Can't list users: %s", err.Error()),
+			},
+		)
+		return
+	}
+
+	_ = d.telegramBot.SendMessage(
+		ctx, &guard.Message{
+			ChatID:   commandChatID,
+			ThreadID: threadIDOf(update),
+			Text:     rendering,
+		},
+	)
+}
+
+// resolveUsersTarget extracts the originating chat id and the requested channel
+// id from either a message ("/users <id>") or a callback ("/users <id>").
+func (d *Domain) resolveUsersTarget(update *guard.Update) (commandChatID, channelID int64, ok bool) {
+	switch {
+	case update.Message != nil:
+		commandChatID = update.Message.ChatID
+		channelID, ok = parseUsersChannelArg(update.Message.Text)
+		if !ok {
+			_ = d.telegramBot.SendMessage(
+				context.Background(), &guard.Message{
+					ChatID:   commandChatID,
+					ThreadID: update.Message.ThreadID,
+					Text:     "Usage: /users <channel_id> (pick a channel from /list)",
+				},
+			)
+			return 0, 0, false
+		}
+	case update.CallbackQuery != nil && update.CallbackQuery.Message != nil:
+		commandChatID = update.CallbackQuery.Message.ChatID
+		channelID, ok = parseUsersChannelArg(update.CallbackQuery.Data)
+		if !ok {
+			d.telegramBot.CallbackResponse(
+				context.Background(),
+				guard.CallbackResponse{ID: update.CallbackQuery.ID, Text: "Bad channel id", ShowAlert: true},
+			)
+			return 0, 0, false
+		}
+		d.telegramBot.CallbackResponse(
+			context.Background(),
+			guard.CallbackResponse{ID: update.CallbackQuery.ID},
+		)
+	default:
+		return 0, 0, false
+	}
+	return commandChatID, channelID, true
+}
+
+// parseUsersChannelArg extracts the integer channel id from a payload of the
+// form "/users <id>". Returns false on parse failure.
+func parseUsersChannelArg(data string) (int64, bool) {
+	parts := strings.Split(data, " ")
+	if len(parts) < 2 {
+		return 0, false
+	}
+	id, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return id, true
+}
+
+// renderChannelUsers fetches the members of channelID, classifies them with the
+// channel's access checker, and returns an HTML rendering split into Good /
+// Unknown / Bad. Large listings are truncated to keep within Telegram's message
+// length limit.
+func (d *Domain) renderChannelUsers(ctx context.Context, channelID int64) (string, error) {
+	protectedChannel, found := d.protectedChannels[channelID]
+	channel, channelFound := d.channels[channelID]
+
+	if !found {
+		return "", fmt.Errorf("channel %d is not protected", channelID)
+	}
+
+	title := fmt.Sprintf("%d", channelID)
+	if channelFound {
+		title = channel.title
+	}
+
+	if d.userBot == nil {
+		return "", fmt.Errorf("userbot is not running")
+	}
+
+	users, err := d.userBot.GetChannelUsers(ctx, channelID)
+	if err != nil {
+		return "", fmt.Errorf("get channel users: %w", err)
+	}
+
+	checker := protectedChannel.AccessChecker
+	if checker == nil {
+		checker = d.defaultAccessChecker
+	}
+	if checker == nil {
+		return "", fmt.Errorf("no access checker configured")
+	}
+
+	var good, unknown, bad []guard.User
+	for _, user := range users {
+		user := user
+		hasAccess, err := checker.HasAccess(ctx, &user)
+		if err != nil {
+			unknown = append(unknown, user)
+			continue
+		}
+		if hasAccess {
+			good = append(good, user)
+		} else {
+			bad = append(bad, user)
+		}
+	}
+
+	return formatUsersReport(title, good, unknown, bad), nil
+}
+
+// formatUsersReport builds the HTML message. It truncates each section to a
+// per-section cap so the whole message stays comfortably under Telegram's 4096
+// character limit even for large channels.
+func formatUsersReport(title string, good, unknown, bad []guard.User) string {
+	const perSectionCap = 40
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "<b>Users of %s</b>\n\n", title)
+	fmt.Fprintf(&b, "<b>Summary</b>: Good <b>%d</b> · Unknown <b>%d</b> · Bad <b>%d</b>\n",
+		len(good), len(unknown), len(bad))
+
+	appendSection(&b, "Good", good, perSectionCap)
+	appendSection(&b, "Unknown", unknown, perSectionCap)
+	appendSection(&b, "Bad", bad, perSectionCap)
+
+	if len(good)+len(unknown)+len(bad) > perSectionCap*3 {
+		b.WriteString("\n<i>List truncated. Run /scan for a full persisted report.</i>")
+	}
+	return b.String()
+}
+
+func appendSection(b *strings.Builder, label string, users []guard.User, cap int) {
+	if len(users) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "\n<b>%s (%d):</b>\n", label, len(users))
+	shown := users
+	truncated := false
+	if len(shown) > cap {
+		shown = shown[:cap]
+		truncated = true
+	}
+	for _, u := range shown {
+		b.WriteString("• ")
+		b.WriteString(userLink(u))
+		b.WriteString("\n")
+	}
+	if truncated {
+		fmt.Fprintf(b, "… and %d more\n", len(users)-cap)
+	}
+}
+
+// userLink renders an HTML link to a user, preferring username, then phone, then
+// an inline tg://user link. Mirrors the reporter's getUserLink logic but kept
+// local to avoid a cross-package dependency.
+func userLink(u guard.User) string {
+	lastname := ""
+	if len(u.LastName) > 0 {
+		lastname = " " + u.LastName
+	}
+	switch {
+	case len(u.Username) > 0:
+		return fmt.Sprintf(`<a href="https://t.me/%s">%s%s</a>`, u.Username, u.FirstName, lastname)
+	case u.Phone != nil:
+		return fmt.Sprintf(`<a href="https://t.me/+%s">%s%s</a>`, *u.Phone, u.FirstName, lastname)
+	default:
+		return fmt.Sprintf(`<a href="tg://user?id=%d">%s%s</a>`, u.ID, u.FirstName, lastname)
+	}
+}
+
+// threadIDOf is a small helper to pull the thread id from whichever message
+// shape an update carries.
+func threadIDOf(update *guard.Update) *int {
+	if update.Message != nil {
+		return update.Message.ThreadID
+	}
+	if update.CallbackQuery != nil && update.CallbackQuery.Message != nil {
+		return update.CallbackQuery.Message.ThreadID
+	}
+	return nil
+}

--- a/controllers/scanner/handler_users_test.go
+++ b/controllers/scanner/handler_users_test.go
@@ -1,0 +1,96 @@
+package scanner
+
+import (
+	"strings"
+	"testing"
+
+	guard "github.com/MobDev-Hobby/telegram-nda-guard"
+)
+
+func TestFormatUsersReport_ContainsCountsAndSections(t *testing.T) {
+	good := []guard.User{{ID: 1, FirstName: "Alice", Username: "alice"}}
+	unknown := []guard.User{{ID: 2, FirstName: "Bob"}}
+	bad := []guard.User{
+		{ID: 3, FirstName: "Eve"},
+		{ID: 4, FirstName: "Mallory"},
+	}
+
+	out := formatUsersReport("My Channel", good, unknown, bad)
+
+	checks := []string{
+		"Users of My Channel",
+		"Good <b>1</b>",
+		"Unknown <b>1</b>",
+		"Bad <b>2</b>",
+		"Good (1):",
+		"Bad (2):",
+		"t.me/alice", // username link present
+	}
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q\nfull:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatUsersReport_TruncatesLargeSections(t *testing.T) {
+	// 50 bad users — over the per-section cap of 40.
+	big := make([]guard.User, 50)
+	for i := range big {
+		big[i] = guard.User{ID: int64(i), FirstName: "u"}
+	}
+	out := formatUsersReport("Big", nil, nil, big)
+
+	if !strings.Contains(out, "… and 10 more") {
+		t.Errorf("expected truncation marker, got:\n%s", out)
+	}
+}
+
+func TestFormatUsersReport_OmitsEmptySections(t *testing.T) {
+	out := formatUsersReport("Ch", []guard.User{{ID: 1, FirstName: "A"}}, nil, nil)
+	if strings.Contains(out, "Unknown (") {
+		t.Errorf("empty Unknown section should be omitted:\n%s", out)
+	}
+	if strings.Contains(out, "Bad (") {
+		t.Errorf("empty Bad section should be omitted:\n%s", out)
+	}
+}
+
+func TestUserLink_Fallbacks(t *testing.T) {
+	phone := "+15550000"
+	cases := []struct {
+		user guard.User
+		want string
+	}{
+		{guard.User{ID: 1, FirstName: "A", Username: "ali"}, `t.me/ali`},
+		{guard.User{ID: 2, FirstName: "B", Phone: &phone}, `t.me/+` + phone},
+		{guard.User{ID: 3, FirstName: "C"}, `tg://user?id=3`},
+	}
+	for _, c := range cases {
+		got := userLink(c.user)
+		if !strings.Contains(got, c.want) {
+			t.Errorf("userLink %+v = %q, want it to contain %q", c.user, got, c.want)
+		}
+	}
+}
+
+func TestParseUsersChannelArg(t *testing.T) {
+	cases := []struct {
+		in     string
+		wantID int64
+		wantOK bool
+	}{
+		{"/users 123", 123, true},
+		{"/users -100456", -100456, true},
+		{"/users abc", 0, false},
+		{"/users", 0, false},
+		{"", 0, false},
+	}
+	for _, c := range cases {
+		id, ok := parseUsersChannelArg(c.in)
+		if ok != c.wantOK || id != c.wantID {
+			t.Errorf("parseUsersChannelArg(%q) = (%d, %v), want (%d, %v)",
+				c.in, id, ok, c.wantID, c.wantOK)
+		}
+	}
+}


### PR DESCRIPTION
Closes beads issue telegram-nda-guard-ecb (GLM-7).

## What
Adds a read-only, on-demand command to view a channel's members classified by access — the interactive counterpart to /scan (which only emits a persisted report).

## Changes
- /users <id> (message + callback) fetches members via UserBot.GetChannelUsers, classifies them with the channel's access checker (Good / Unknown / Bad), and renders an HTML listing with per-user links.
- Large listings are truncated per-section (cap 40) with a run /scan for full report hint, keeping within Telegram message length limit.
- /list now shows a /users button per channel.
- 5 unit tests: counts/sections, truncation, empty-section omission, user-link fallbacks (username, phone, inline), payload parsing.

## Why
The audit noted there was no way to view channel members interactively — /scan only sends an aggregate report. This gives operators immediate visibility.

## Notes
- Self-contained on master; uses guard.User fields (incl. Phone, Usernames) directly from GetChannelUsers, avoiding the AccessReport copy path that drops those fields.
- When combined with GLM-3 (authorizer), wrap the handler in requireAuth.

## Migration
Additive only — no interface changes. No consumer action required.

## Validation
- go build ./... / go vet ./... pass
- go test ./controllers/scanner/... pass (5/5 new)
- Pre-existing unrelated failure session/file TestNew/empty_session fails on master too.

<!-- reviewed-by: pending codex review -->