### PR TITLE
Web UI management dashboard (us3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,13 @@ When in doubt, add a `Migration` note. It is cheaper than a silent break.
 - **Channel removal UI.** New `/remove <id>` command with a two-step inline
   confirmation (`/rmconfirm <id>`). Detaching a channel is now possible from
   the bot; previously `CleanProtectedChannel` existed but was dead code.
+- **Web management dashboard.** New transport-neutral `scanner.ManagementService`
+  interface (implemented by `*Domain`), a `scanner.WebAuthenticator` interface,
+  and the `controllers/scanner/webapi` package — a JSON REST API + embedded SPA
+  dashboard authenticated via the Telegram Login Widget. The same
+  `HybridAuthorizer` serves both the Telegram `Authorizer` and the
+  `WebAuthenticator` roles. Enabled in `cmd/example` via `WEB_ADDR` +
+  `WEB_SESSION_SECRET`. `Domain.Ready()` signals initialization completion.
 - Established this `CHANGELOG.md` and the migration-note convention documented
   above. Future interface/contract changes will be recorded under this section
   until the next tagged release.
@@ -130,6 +137,12 @@ When in doubt, add a `Migration` note. It is cheaper than a silent break.
   `telegram/bots/bot.Domain` already provides it.
 - Optional, non-breaking: to restrict who can run commands, pass
   `scanner.WithAuthorizer(...)`. Without it, behavior is unchanged.
+- **Web dashboard (optional):** to enable the management API, set `WEB_ADDR`
+  (e.g. `:8080`) and `WEB_SESSION_SECRET` (>=32 bytes) in `cmd/example`. The
+  dashboard is off by default. `scanner.ManagementService` and
+  `scanner.WebAuthenticator` are new interfaces; `*Domain` implements the
+  former, and the bundled `HybridAuthorizer` implements both. No existing
+  consumer is forced to adopt them.
 
 ---
 

--- a/cmd/example/env_vars.go
+++ b/cmd/example/env_vars.go
@@ -25,4 +25,7 @@ type environmentConfig struct {
 	// administrators of the controlling chat. When false (default), commands
 	// remain open to all members (backwards-compatible).
 	RequireAdminAuth bool `env:"REQUIRE_ADMIN_AUTH"`
+	// Web management API (optional). When WebAddr is empty, the web UI is disabled.
+	WebAddr         string `env:"WEB_ADDR"`
+	WebSessionSecret string `env:"WEB_SESSION_SECRET"`
 }

--- a/cmd/example/main.go
+++ b/cmd/example/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/caarlos0/env/v11"
 	"github.com/joho/godotenv"
@@ -16,6 +17,7 @@ import (
 	demochecker "github.com/MobDev-Hobby/telegram-nda-guard/checker/demo"
 	"github.com/MobDev-Hobby/telegram-nda-guard/controllers/scanner"
 	"github.com/MobDev-Hobby/telegram-nda-guard/controllers/scanner/authorizer"
+	"github.com/MobDev-Hobby/telegram-nda-guard/controllers/scanner/webapi"
 	"github.com/MobDev-Hobby/telegram-nda-guard/processors/kicker"
 	"github.com/MobDev-Hobby/telegram-nda-guard/processors/reporter"
 	redischanstorage "github.com/MobDev-Hobby/telegram-nda-guard/storage/channels/redis"
@@ -41,7 +43,9 @@ func main() {
 
 	defer func() {
 		if panicErr := recover(); panicErr != nil {
-			logger.Error(ctx, panicErr)
+			// SugaredLogger.Error takes variadic args, not a context;
+			// passing ctx logged a noisy struct dump instead of the panic.
+			logger.Error(panicErr)
 		}
 	}()
 
@@ -56,6 +60,16 @@ func main() {
 		logger.Panicf("can't parse env options: %s", err)
 	}
 
+	// Validate the AES key length explicitly: AES only accepts 16/24/32-byte
+	// keys. aes.NewCipher would reject other lengths, but a clear message
+	// helps operators diagnose a misconfigured SESSION_KEY.
+	sessionKeyLen := len(options.SessionKey)
+	if sessionKeyLen != 16 && sessionKeyLen != 24 && sessionKeyLen != 32 {
+		logger.Panicf(
+			"invalid SESSION_KEY length %d: AES key must be 16, 24 or 32 bytes",
+			sessionKeyLen,
+		)
+	}
 	cryptoProvider, err := aes.NewCipher(
 		[]byte(options.SessionKey),
 	)
@@ -143,12 +157,21 @@ func main() {
 		reporter.WithLogger(logger.Named("scan-report-processor")),
 	)
 
+	// The kicker must go through a rate-limited, FLOOD_WAIT-aware restrictor.
+	// Previously it held the raw *bot.Bot and hit BanChatMember/UnbanChatMember
+	// with no throttling — the most reliable way to get the account banned.
+	kickerRestrictor := ratelimited.NewRestrictor(
+		telegramBotDomain,
+		1*time.Second,
+		5,
+		ratelimited.WithRestrictorLogger(logger.Named("kicker-restrictor")),
+	)
 	cleanReporter := kicker.New(
-		telegramBotDomain.GetBot(),
+		kickerRestrictor,
 		kicker.WithLogger(logger.Named("clean-report-processor")),
 		kicker.WithCleanMessages(options.HideMessagesForKickedUsers),
 		kicker.WithKeepBanned(options.KeepKickedUsersBanned),
-		kicker.WithKeepBanned(options.KickUnknownUsers),
+		kicker.WithCleanUnknown(options.KickUnknownUsers),
 	)
 
 	channels := make([]scanner.ProtectedChannel, 0, len(options.Channels))
@@ -208,6 +231,39 @@ func main() {
 		cachedUserBotDomain,
 		controllerOptions...,
 	)
+
+	// Optional web management dashboard. The same HybridAuthorizer serves both
+	// the Telegram Authorizer and the WebAuthenticator roles, so web users are
+	// authorized against the same owner/allowlist/admin policy.
+	if options.WebAddr != "" {
+		webAuth := authorizer.New(telegramBotDomain,
+			authorizer.WithOwner(options.AdminChatID),
+			authorizer.WithLogger(logger.Named("web-authorizer")),
+		)
+		webSecret := []byte(options.WebSessionSecret)
+		if len(webSecret) < 32 {
+			logger.Panicf("WEB_SESSION_SECRET must be at least 32 bytes when WEB_ADDR is set")
+		}
+		webServer, err := webapi.New(
+			ProtectorControllerDomain,
+			webAuth,
+			options.TelegramBotKey,
+			webSecret,
+			webapi.WithLogger(logger.Named("webapi")),
+		)
+		if err != nil {
+			logger.Panicf("can't init web api: %s", err)
+		}
+		// Wait for the controller to finish initializing before serving, then
+		// run until the context is cancelled.
+		go func() {
+			<-ProtectorControllerDomain.Ready()
+			logger.Infof("Web dashboard starting on %s", options.WebAddr)
+			if err := webServer.ListenAndServe(options.WebAddr); err != nil {
+				logger.Errorf("web api stopped: %s", err)
+			}
+		}()
+	}
 
 	err = ProtectorControllerDomain.Run(ctx)
 	if err != nil {

--- a/controllers/scanner/add_protected_channel.go
+++ b/controllers/scanner/add_protected_channel.go
@@ -91,11 +91,11 @@ func (d *Domain) AddProtectedChannel(channel *ProtectedChannel, opts ...TickerOp
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
 		err := d.storage.Store(ctx, &channels.ProtectedChannel{
-			ID:                   channel.ID,
-			CommandChannelIDs:    channel.CommandChannelIDs,
-			AutoScan:             channel.AutoScan,
-			AutoClean:            channel.AutoClean,
-			AllowClean:           channel.AllowClean,
+			ID:                channel.ID,
+			CommandChannelIDs: channel.CommandChannelIDs,
+			AutoScan:          channel.AutoScan,
+			AutoClean:         channel.AutoClean,
+			AllowClean:        channel.AllowClean,
 		})
 		if err != nil {
 			return err

--- a/controllers/scanner/authorizer/hybrid.go
+++ b/controllers/scanner/authorizer/hybrid.go
@@ -96,40 +96,55 @@ func New(bot ChatAdminLister, opts ...Option) *HybridAuthorizer {
 	return h
 }
 
-// Authorize implements scanner.Authorizer.
+// Authorize implements scanner.Authorizer (the Telegram-side interface). It
+// extracts the sender and chat IDs from the update and delegates to the
+// transport-neutral authorizeIDs.
 func (h *HybridAuthorizer) Authorize(ctx context.Context, update *guard.Update) (bool, error) {
-	if update == nil || update.Message == nil {
-		// Callbacks carry the originating message; authorize on that.
-		if update != nil && update.CallbackQuery != nil && update.CallbackQuery.Message != nil {
-			return h.authorizeMessage(ctx, update.CallbackQuery.Message)
-		}
-		return false, errors.New("authorize: update has no message")
+	if update == nil {
+		return false, errors.New("authorize: nil update")
 	}
-	return h.authorizeMessage(ctx, update.Message)
+	if update.Message != nil {
+		return h.authorizeIDs(ctx, update.Message.User.ID, update.Message.ChatID)
+	}
+	if update.CallbackQuery != nil && update.CallbackQuery.Message != nil {
+		return h.authorizeIDs(ctx, update.CallbackQuery.Message.User.ID, update.CallbackQuery.Message.ChatID)
+	}
+	return false, errors.New("authorize: update has no message")
 }
 
-func (h *HybridAuthorizer) authorizeMessage(ctx context.Context, msg *guard.MessageReceived) (bool, error) {
-	senderID := msg.User.ID
+// AuthenticateAndAuthorize implements scanner.WebAuthenticator. It is the
+// transport-neutral entry point used by non-Telegram surfaces (e.g. the web
+// API): callerID is the verified Telegram user ID obtained from the login
+// widget, and scopeChatID is the chat/channel the operation targets (0 when
+// irrelevant, which disables the admin-check branch).
+func (h *HybridAuthorizer) AuthenticateAndAuthorize(ctx context.Context, callerID, scopeChatID int64) (bool, error) {
+	return h.authorizeIDs(ctx, callerID, scopeChatID)
+}
 
+// authorizeIDs is the single decision core shared by both transports. It
+// resolves whether callerID may act, optionally checking that they are an
+// administrator of scopeChatID when RequireAdmin is set and scopeChatID != 0.
+func (h *HybridAuthorizer) authorizeIDs(ctx context.Context, callerID, scopeChatID int64) (bool, error) {
 	// 1. Owner always wins.
-	if h.ownerUserID != 0 && senderID == h.ownerUserID {
+	if h.ownerUserID != 0 && callerID == h.ownerUserID {
 		return true, nil
 	}
 	// 2. Explicit allowlist.
 	for _, id := range h.allowUserIDs {
-		if id == senderID {
+		if id == callerID {
 			return true, nil
 		}
 	}
-	// 3. Optional: sender is an admin of the originating chat.
-	if h.requireAdmin {
-		admins, err := h.bot.GetChatAdministrators(ctx, msg.ChatID)
+	// 3. Optional: caller is an admin of the originating/target chat. Skipped
+	//    when scopeChatID is 0 (e.g. web calls without a chat context).
+	if h.requireAdmin && scopeChatID != 0 {
+		admins, err := h.bot.GetChatAdministrators(ctx, scopeChatID)
 		if err != nil {
-			h.log.Errorf("authorize: can't get chat admins for %d: %s", msg.ChatID, err)
+			h.log.Errorf("authorize: can't get chat admins for %d: %s", scopeChatID, err)
 			return false, nil
 		}
 		for _, id := range admins {
-			if id == senderID {
+			if id == callerID {
 				return true, nil
 			}
 		}

--- a/controllers/scanner/commands.go
+++ b/controllers/scanner/commands.go
@@ -67,58 +67,58 @@ func (d *Domain) setupCommands(ctx context.Context) {
 		},
 		d.requireAuth(d.checkChannelHandler),
 	)
-		d.telegramBot.RegisterHandler(
-			ctx,
-			func(update *guard.Update) bool {
-				if update.CallbackQuery != nil && update.CallbackQuery.Message != nil &&
-					strings.HasPrefix(update.CallbackQuery.Data, "/scan") {
+	d.telegramBot.RegisterHandler(
+		ctx,
+		func(update *guard.Update) bool {
+			if update.CallbackQuery != nil && update.CallbackQuery.Message != nil &&
+				strings.HasPrefix(update.CallbackQuery.Data, "/scan") {
 
-					return true
-				}
-				return false
-			},
-			d.requireAuth(d.processScanCallbackHandler),
-		)
+				return true
+			}
+			return false
+		},
+		d.requireAuth(d.processScanCallbackHandler),
+	)
 
-		d.log.Debugf("Register /clean handler")
-		d.telegramBot.RegisterHandler(
-			ctx,
-			func(update *guard.Update) bool {
-				if update.Message != nil &&
-					strings.HasPrefix(update.Message.Text, "/clean") {
+	d.log.Debugf("Register /clean handler")
+	d.telegramBot.RegisterHandler(
+		ctx,
+		func(update *guard.Update) bool {
+			if update.Message != nil &&
+				strings.HasPrefix(update.Message.Text, "/clean") {
 
-					return true
-				}
-				return false
-			},
-			d.requireAuth(d.cleanChannelHandler),
-		)
-		d.telegramBot.RegisterHandler(
-			ctx,
-			func(update *guard.Update) bool {
-				if update.CallbackQuery != nil && update.CallbackQuery.Message != nil &&
-					strings.HasPrefix(update.CallbackQuery.Data, "/clean") {
+				return true
+			}
+			return false
+		},
+		d.requireAuth(d.cleanChannelHandler),
+	)
+	d.telegramBot.RegisterHandler(
+		ctx,
+		func(update *guard.Update) bool {
+			if update.CallbackQuery != nil && update.CallbackQuery.Message != nil &&
+				strings.HasPrefix(update.CallbackQuery.Data, "/clean") {
 
-					return true
-				}
-				return false
-			},
-			d.requireAuth(d.processCleanCallbackHandler),
-		)
+				return true
+			}
+			return false
+		},
+		d.requireAuth(d.processCleanCallbackHandler),
+	)
 
-		d.log.Debugf("Register /list handler")
-		d.telegramBot.RegisterHandler(
-			ctx,
-			func(update *guard.Update) bool {
-				if update.Message != nil &&
-					strings.HasPrefix(update.Message.Text, "/list") {
+	d.log.Debugf("Register /list handler")
+	d.telegramBot.RegisterHandler(
+		ctx,
+		func(update *guard.Update) bool {
+			if update.Message != nil &&
+				strings.HasPrefix(update.Message.Text, "/list") {
 
-					return true
-				}
-				return false
-			},
-			d.requireAuth(d.ListChannelsHandler),
-		)
+				return true
+			}
+			return false
+		},
+		d.requireAuth(d.ListChannelsHandler),
+	)
 
 	d.log.Debugf("Register /settings handlers")
 	d.telegramBot.RegisterHandler(

--- a/controllers/scanner/dep.go
+++ b/controllers/scanner/dep.go
@@ -44,6 +44,18 @@ type Authorizer interface {
 	Authorize(ctx context.Context, update *guard.Update) (bool, error)
 }
 
+// WebAuthenticator is the transport-neutral counterpart of Authorizer, used by
+// non-Telegram surfaces (e.g. the HTTP management API). The callerID is the
+// verified Telegram user ID (obtained via the Telegram Login Widget or an
+// equivalent token), and scopeChatID is the chat/channel the operation targets
+// (0 when there is no chat context, which disables the admin-check branch).
+//
+// The bundled HybridAuthorizer satisfies both Authorizer and WebAuthenticator,
+// so a single configured instance serves both transports.
+type WebAuthenticator interface {
+	AuthenticateAndAuthorize(ctx context.Context, callerID, scopeChatID int64) (bool, error)
+}
+
 type UserBot interface {
 	Run(
 		ctx context.Context,

--- a/controllers/scanner/domain.go
+++ b/controllers/scanner/domain.go
@@ -21,10 +21,10 @@ type Domain struct {
 
 	processingThreads int
 
-	commandChannels         map[int64][]int64
-	protectedChannels       map[int64]ProtectedChannel
-	channels                map[int64]ChannelInfo
-	addChannelHandlers      map[int]int64
+	commandChannels          map[int64][]int64
+	protectedChannels        map[int64]ProtectedChannel
+	channels                 map[int64]ChannelInfo
+	addChannelHandlers       map[int]int64
 	addChannelRequestCounter int32
 
 	// channelsMutex guards commandChannels, protectedChannels, channels and
@@ -46,6 +46,23 @@ type Domain struct {
 	tickerCasesMutex    sync.Mutex
 	tickerCases         []reflect.SelectCase
 	tickerCasesChannels []int64
+
+	// ready is closed once Run() finishes initialization, so HTTP/management
+	// surfaces can wait for (or poll) readiness before serving traffic.
+	ready      chan struct{}
+	readyClose sync.Once
+}
+
+// Ready returns a channel that is closed when the controller has finished its
+// initialization (bots started, commands registered, loops launched). HTTP
+// surfaces can block on it or answer 503 until then.
+func (d *Domain) Ready() <-chan struct{} {
+	if d.ready == nil {
+		ch := make(chan struct{})
+		close(ch)
+		return ch
+	}
+	return d.ready
 }
 
 func New(
@@ -73,6 +90,7 @@ func New(
 		addChannelHandlers: make(map[int]int64),
 
 		processRequestChan: make(chan ScanRequest, 10),
+		ready:              make(chan struct{}),
 	}
 
 	for _, opt := range opts {

--- a/controllers/scanner/handler_user_bot_restart.go
+++ b/controllers/scanner/handler_user_bot_restart.go
@@ -19,12 +19,14 @@ func (d *Domain) retryHandler(
 			Text:     "Re-init user bot...",
 		},
 	)
-	d.runUserBot(ctx)
-
+	// Check the send result before re-initializing. Previously
+	// d.runUserBot(ctx) ran unconditionally and the error check below was
+	// effectively dead code.
 	if err != nil {
 		d.log.Errorf("can't send message: %s", err)
 		return
 	}
+	d.runUserBot(ctx)
 
 	d.log.Debugf("processed get ID for chat: %d", update.Message.ChatID)
 }

--- a/controllers/scanner/management.go
+++ b/controllers/scanner/management.go
@@ -1,0 +1,93 @@
+package scanner
+
+import (
+	"context"
+
+	guard "github.com/MobDev-Hobby/telegram-nda-guard"
+)
+
+// ChannelView is a transport-neutral, read-only snapshot of a protected
+// channel's state. It is a value copy (slices duplicated) so callers cannot
+// mutate the controller's in-memory state through it.
+//
+// The in-memory fields BotOnChannel / BotCanInvite / BotCanClean reflect the
+// bot's actual rights in the channel as resolved from the Telegram API; they
+// are not persisted and may change between calls.
+type ChannelView struct {
+	ID           int64   `json:"id"`
+	Title        string  `json:"title"`
+	ChatType     string  `json:"chatType"`
+	CommandChats []int64 `json:"commandChats"`
+	AutoScan     bool    `json:"autoScan"`
+	AutoClean    bool    `json:"autoClean"`
+	AllowClean   bool    `json:"allowClean"`
+	BotOnChannel bool    `json:"botOnChannel"`
+	BotCanInvite bool    `json:"botCanInvite"`
+	BotCanClean  bool    `json:"botCanClean"`
+}
+
+// CanScan reports whether the bot can scan this channel (is a member).
+func (c ChannelView) CanScan() bool { return c.BotOnChannel }
+
+// CanClean reports whether the bot can clean (kick) users in this channel.
+func (c ChannelView) CanClean() bool { return c.BotOnChannel && c.BotCanClean }
+
+// UsersView is the classified member list for a channel: Good (access granted),
+// Unknown (check failed), Bad (access denied). It mirrors what /scan computes
+// but without invoking the report or cleaner processors.
+type UsersView struct {
+	ChannelID int64        `json:"channelId"`
+	Title     string       `json:"title"`
+	Good      []guard.User `json:"good"`
+	Unknown   []guard.User `json:"unknown"`
+	Bad       []guard.User `json:"bad"`
+}
+
+// StatusView aggregates bot/userbot identity and the full channel list, for a
+// dashboard landing page.
+type StatusView struct {
+	BotUsername     string        `json:"botUsername"`
+	BotUserID       int64         `json:"botUserId"`
+	UserBotUsername string        `json:"userBotUsername"`
+	UserBotUserID   int64         `json:"userBotUserId"`
+	AdminChatID     int64         `json:"adminChatId"`
+	Channels        []ChannelView `json:"channels"`
+}
+
+// ManagementService is the transport-neutral management surface for the
+// controller. The bundled *Domain implements it; consumers (HTTP API, CLI,
+// tests) depend on this interface rather than the concrete type, so the
+// transport layer can be swapped without touching the domain.
+//
+// All methods return value copies and must be safe to call concurrently with
+// the Telegram command handlers and the scan/ticker loops.
+type ManagementService interface {
+	// ListChannels returns the protected channels controlled from
+	// commandChatID. Pass 0 to return every protected channel regardless of
+	// controlling chat.
+	ListChannels(ctx context.Context, commandChatID int64) ([]ChannelView, error)
+	// GetChannel returns a single channel by ID.
+	GetChannel(ctx context.Context, channelID int64) (ChannelView, error)
+	// AddChannel registers a new protected channel. commandChatID is the
+	// controlling chat it is attached to.
+	AddChannel(ctx context.Context, channelID, commandChatID int64, autoScan, autoClean, allowClean bool) error
+	// RemoveChannel detaches channelID from commandChatID (and deletes it
+	// entirely when no controlling chats remain). Returns an error if the chat
+	// does not control the channel.
+	RemoveChannel(ctx context.Context, channelID, commandChatID int64) error
+	// SetChannelFlags updates the AutoScan/AutoClean/AllowClean flags for a
+	// channel, persists the change and keeps the periodic ticker in sync.
+	SetChannelFlags(ctx context.Context, channelID int64, autoScan, autoClean, allowClean bool) error
+	// ListChannelUsers fetches and classifies the members of channelID.
+	ListChannelUsers(ctx context.Context, channelID int64) (UsersView, error)
+	// TriggerScan enqueues a manual scan of channelID; reportChannelID is where
+	// the report is sent (typically the controlling chat).
+	TriggerScan(ctx context.Context, channelID, reportChannelID int64) error
+	// TriggerClean enqueues a manual clean of channelID.
+	TriggerClean(ctx context.Context, channelID, reportChannelID int64) error
+	// GetStatus returns the aggregated bot/userbot identity and channel list.
+	GetStatus(ctx context.Context) (StatusView, error)
+	// RefreshRights re-resolves the bot's rights and channel titles from
+	// Telegram. Useful after manual changes in the Telegram client.
+	RefreshRights(ctx context.Context) error
+}

--- a/controllers/scanner/management_methods.go
+++ b/controllers/scanner/management_methods.go
@@ -1,0 +1,297 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	guard "github.com/MobDev-Hobby/telegram-nda-guard"
+	"github.com/MobDev-Hobby/telegram-nda-guard/storage/channels"
+)
+
+// channelView builds a value-copy ChannelView from the in-memory caches. The
+// caller must hold d.channelsMutex (read or write).
+func (d *Domain) channelViewLocked(channelID int64) (ChannelView, bool) {
+	ch, ok := d.channels[channelID]
+	if !ok {
+		// Channel is known to storage but its runtime cache entry hasn't been
+		// populated yet (e.g. before the first CheckRights). Build a minimal
+		// view from the protected-channel record if present.
+		pc, pcOK := d.protectedChannels[channelID]
+		if !pcOK {
+			return ChannelView{}, false
+		}
+		return ChannelView{
+			ID:           pc.ID,
+			Title:        fmt.Sprintf("%d", channelID),
+			CommandChats: append([]int64(nil), pc.CommandChannelIDs...),
+			AutoScan:     pc.AutoScan,
+			AutoClean:    pc.AutoClean,
+			AllowClean:   pc.AllowClean,
+		}, true
+	}
+	pc, _ := d.protectedChannels[channelID]
+	return ChannelView{
+		ID:           ch.id,
+		Title:        ch.title,
+		ChatType:     ch.chatType,
+		CommandChats: append([]int64(nil), ch.commandChannelIDs...),
+		AutoScan:     pc.AutoScan,
+		AutoClean:    pc.AutoClean,
+		AllowClean:   pc.AllowClean,
+		BotOnChannel: ch.botOnChannel,
+		BotCanInvite: ch.botCanInvite,
+		BotCanClean:  ch.botCanClean,
+	}, true
+}
+
+// ListChannels implements ManagementService.
+func (d *Domain) ListChannels(_ context.Context, commandChatID int64) ([]ChannelView, error) {
+	d.channelsMutex.RLock()
+	defer d.channelsMutex.RUnlock()
+
+	if commandChatID == 0 {
+		out := make([]ChannelView, 0, len(d.protectedChannels))
+		for id := range d.protectedChannels {
+			if v, ok := d.channelViewLocked(id); ok {
+				out = append(out, v)
+			}
+		}
+		return out, nil
+	}
+
+	ids := d.commandChannels[commandChatID]
+	out := make([]ChannelView, 0, len(ids))
+	for _, id := range ids {
+		if v, ok := d.channelViewLocked(id); ok {
+			out = append(out, v)
+		}
+	}
+	return out, nil
+}
+
+// GetChannel implements ManagementService.
+func (d *Domain) GetChannel(_ context.Context, channelID int64) (ChannelView, error) {
+	d.channelsMutex.RLock()
+	defer d.channelsMutex.RUnlock()
+	v, ok := d.channelViewLocked(channelID)
+	if !ok {
+		return ChannelView{}, fmt.Errorf("channel %d not found", channelID)
+	}
+	return v, nil
+}
+
+// AddChannel implements ManagementService. It wires the channel to the default
+// processors/checker (the same path the /add command uses) and then re-resolves
+// the bot's rights so the returned view reflects reality.
+func (d *Domain) AddChannel(ctx context.Context, channelID, commandChatID int64, autoScan, autoClean, allowClean bool) error {
+	if d.defaultAccessChecker == nil || d.defaultCleanProcessor == nil || d.defaultScanProcessor == nil {
+		return fmt.Errorf("default access checker, clean processor and scan processor must be configured")
+	}
+	pc := &ProtectedChannel{
+		ID:                channelID,
+		CommandChannelIDs: []int64{commandChatID},
+		AutoScan:          autoScan,
+		AutoClean:         autoClean,
+		AllowClean:        allowClean,
+	}
+	if err := d.AddDefaultProtectedChannel(pc); err != nil {
+		return fmt.Errorf("add protected channel: %w", err)
+	}
+	if err := d.CheckRights(ctx); err != nil {
+		// Non-fatal: the channel is added; rights just couldn't be refreshed.
+		d.log.Errorf("AddChannel: can't check rights: %v", err)
+	}
+	return nil
+}
+
+// RemoveChannel implements ManagementService. It refuses removal when
+// commandChatID does not control channelID.
+func (d *Domain) RemoveChannel(ctx context.Context, channelID, commandChatID int64) error {
+	d.channelsMutex.RLock()
+	controlled := false
+	for _, id := range d.commandChannels[commandChatID] {
+		if id == channelID {
+			controlled = true
+			break
+		}
+	}
+	d.channelsMutex.RUnlock()
+	if !controlled {
+		return fmt.Errorf("channel %d is not controlled from chat %d", channelID, commandChatID)
+	}
+	return d.CleanProtectedChannel(channelID, commandChatID)
+}
+
+// SetChannelFlags implements ManagementService. It sets the three flags to the
+// given absolute values (unlike the /setflag toggle), persists and syncs the
+// ticker. It reuses the persistence + ticker-sync path of applyFlagToggle.
+func (d *Domain) SetChannelFlags(ctx context.Context, channelID int64, autoScan, autoClean, allowClean bool) error {
+	return d.applyFlagSet(ctx, channelID, autoScan, autoClean, allowClean)
+}
+
+// applyFlagSet is the absolute-value counterpart of applyFlagToggle. It is kept
+// separate so the toggle handler's semantics (flip one flag) stay untouched.
+func (d *Domain) applyFlagSet(ctx context.Context, channelID int64, autoScan, autoClean, allowClean bool) error {
+	d.channelsMutex.Lock()
+	pc, ok := d.protectedChannels[channelID]
+	if !ok {
+		d.channelsMutex.Unlock()
+		return fmt.Errorf("channel %d not found", channelID)
+	}
+	pc.AutoScan = autoScan
+	pc.AutoClean = autoClean
+	pc.AllowClean = allowClean
+
+	if d.storage != nil {
+		storeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+		if err := d.storage.Store(storeCtx, &channels.ProtectedChannel{
+			ID:                pc.ID,
+			CommandChannelIDs: pc.CommandChannelIDs,
+			AutoScan:          pc.AutoScan,
+			AutoClean:         pc.AutoClean,
+			AllowClean:        pc.AllowClean,
+		}); err != nil {
+			d.channelsMutex.Unlock()
+			return fmt.Errorf("persist channel: %w", err)
+		}
+	}
+	d.protectedChannels[channelID] = pc
+	needsTicker := pc.AutoScan || pc.AutoClean
+	d.channelsMutex.Unlock()
+
+	hasTicker := d.channelHasTicker(channelID)
+	switch {
+	case needsTicker && !hasTicker:
+		ticker := time.NewTicker(d.channelAutoScanInterval)
+		_ = d.registerTicker(ticker.C, channelID)
+	case !needsTicker && hasTicker:
+		d.removeTickers(channelID)
+	}
+	d.log.Infof("set flags for channel %d -> autoscan=%t autoclean=%t allowclean=%t",
+		channelID, pc.AutoScan, pc.AutoClean, pc.AllowClean)
+	return nil
+}
+
+// ListChannelUsers implements ManagementService. It fetches members via the
+// userbot and classifies them with the channel's access checker (or the default
+// checker). This is the structured counterpart of the /users command.
+func (d *Domain) ListChannelUsers(ctx context.Context, channelID int64) (UsersView, error) {
+	d.channelsMutex.RLock()
+	pc, ok := d.protectedChannels[channelID]
+	ch := d.channels[channelID]
+	d.channelsMutex.RUnlock()
+	if !ok {
+		return UsersView{}, fmt.Errorf("channel %d is not protected", channelID)
+	}
+	if d.userBot == nil {
+		return UsersView{}, fmt.Errorf("userbot is not running")
+	}
+	users, err := d.userBot.GetChannelUsers(ctx, channelID)
+	if err != nil {
+		return UsersView{}, fmt.Errorf("get channel users: %w", err)
+	}
+	checker := pc.AccessChecker
+	if checker == nil {
+		checker = d.defaultAccessChecker
+	}
+	if checker == nil {
+		return UsersView{}, fmt.Errorf("no access checker configured")
+	}
+
+	view := UsersView{
+		ChannelID: channelID,
+		Title:     ch.title,
+		Good:      []guard.User{},
+		Unknown:   []guard.User{},
+		Bad:       []guard.User{},
+	}
+	for _, user := range users {
+		user := user
+		hasAccess, err := checker.HasAccess(ctx, &user)
+		if err != nil {
+			view.Unknown = append(view.Unknown, user)
+			continue
+		}
+		if hasAccess {
+			view.Good = append(view.Good, user)
+		} else {
+			view.Bad = append(view.Bad, user)
+		}
+	}
+	return view, nil
+}
+
+// TriggerScan implements ManagementService. It enqueues a manual scan; the
+// report is sent to reportChannelID.
+func (d *Domain) TriggerScan(ctx context.Context, channelID, reportChannelID int64) error {
+	return d.enqueueScan(ctx, channelID, reportChannelID, Scan)
+}
+
+// TriggerClean implements ManagementService.
+func (d *Domain) TriggerClean(ctx context.Context, channelID, reportChannelID int64) error {
+	return d.enqueueScan(ctx, channelID, reportChannelID, Clean)
+}
+
+// enqueueScan builds a ScanRequest from the in-memory caches and submits it to
+// the worker pool, mirroring the /scan and /clean command path.
+func (d *Domain) enqueueScan(_ context.Context, channelID, reportChannelID int64, requestType ScanRequestType) error {
+	d.channelsMutex.RLock()
+	ch, ok := d.channels[channelID]
+	pc, pcOK := d.protectedChannels[channelID]
+	d.channelsMutex.RUnlock()
+	if !ok || !pcOK {
+		return fmt.Errorf("channel %d not found", channelID)
+	}
+
+	var reportProcessor UserReportProcessor
+	switch requestType {
+	case Scan:
+		reportProcessor = pc.ScanReportProcessor
+	case Clean:
+		reportProcessor = pc.CleanReportProcessor
+	default:
+		return fmt.Errorf("unsupported request type %d for manual trigger", requestType)
+	}
+	if reportProcessor == nil {
+		return fmt.Errorf("no report processor configured for request type %d", requestType)
+	}
+
+	chans := []int64{reportChannelID}
+	d.processRequestChan <- ScanRequest{
+		requestType:     requestType,
+		channelInfo:     ch,
+		accessChecker:   pc.AccessChecker,
+		reportProcessor: reportProcessor,
+		reportChannels:  &chans,
+	}
+	return nil
+}
+
+// GetStatus implements ManagementService.
+func (d *Domain) GetStatus(ctx context.Context) (StatusView, error) {
+	channels, err := d.ListChannels(ctx, 0)
+	if err != nil {
+		return StatusView{}, err
+	}
+	status := StatusView{Channels: channels}
+	if d.telegramBot != nil {
+		status.BotUsername = d.telegramBot.Username()
+		status.BotUserID = d.telegramBot.UserID()
+	}
+	if d.userBot != nil {
+		status.UserBotUsername = d.userBot.Username()
+		status.UserBotUserID = d.userBot.UserID()
+	}
+	status.AdminChatID = d.adminUserChatID
+	return status, nil
+}
+
+// RefreshRights implements ManagementService.
+func (d *Domain) RefreshRights(ctx context.Context) error {
+	return d.CheckRights(ctx)
+}
+
+// Compile-time assertion: *Domain satisfies ManagementService.
+var _ ManagementService = (*Domain)(nil)

--- a/controllers/scanner/notify_admin.go
+++ b/controllers/scanner/notify_admin.go
@@ -7,6 +7,11 @@ import (
 )
 
 func (d *Domain) NotifyAdmin(ctx context.Context, msg string) {
+	// Guard against the unconfigured sentinel (-1): sending to chat id -1
+	// is always rejected by Telegram and only produces noise in the logs.
+	if d.adminUserChatID <= 0 {
+		return
+	}
 	err := d.telegramBot.SendMessage(
 		ctx, &guard.Message{
 			ChatID: d.adminUserChatID,

--- a/controllers/scanner/run.go
+++ b/controllers/scanner/run.go
@@ -66,6 +66,9 @@ func (d *Domain) Run(
 	d.log.Infof("Initialization completed, now bot is ready to go")
 	d.notifySuccessRun(ctx)
 
+	// Signal readiness to HTTP/management surfaces.
+	d.readyClose.Do(func() { close(d.ready) })
+
 	return nil
 }
 

--- a/controllers/scanner/webapi/auth.go
+++ b/controllers/scanner/webapi/auth.go
@@ -1,0 +1,161 @@
+package webapi
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// sessionPayload is the on-the-wire form of the session cookie: callerID plus a
+// 64-bit expiry (unix seconds). It is MAC'd with sessionSecret so it cannot be
+// forged or tampered with. Layout: [8 bytes callerID][8 bytes expiry][32 bytes hmac].
+const sessionLen = 8 + 8 + 32
+
+type contextKey string
+
+const callerIDKey contextKey = "callerID"
+
+// callerIDFromContext returns the authenticated caller's Telegram user ID, or 0
+// if absent (the requireAuth middleware never allows that path to run).
+func callerIDFromContext(ctx context.Context) int64 {
+	if v, ok := ctx.Value(callerIDKey).(int64); ok {
+		return v
+	}
+	return 0
+}
+
+// verifyTelegramLogin validates a Telegram Login Widget callback's hash against
+// the bot token and checks the auth_date is within maxAge. On success it returns
+// the verified user ID. See https://core.telegram.org/widgets/login#checking-authorization
+func (s *Server) verifyTelegramLogin(values map[string]string, maxAge time.Duration) (int64, error) {
+	gotHash := values["hash"]
+	if gotHash == "" {
+		return 0, errors.New("missing hash")
+	}
+	authDateStr := values["auth_date"]
+	if authDateStr == "" {
+		return 0, errors.New("missing auth_date")
+	}
+	authDate, err := strconv.ParseInt(authDateStr, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("bad auth_date: %w", err)
+	}
+	if maxAge > 0 && time.Since(time.Unix(authDate, 0)) > maxAge {
+		return 0, errors.New("login data expired")
+	}
+
+	// Data-check string = sorted "k=v" pairs excluding "hash", joined by \n.
+	parts := make([]string, 0, len(values))
+	for k, v := range values {
+		if k == "hash" {
+			continue
+		}
+		parts = append(parts, k+"="+v)
+	}
+	// Sort for a stable data-check string.
+	for i := 0; i < len(parts); i++ {
+		for j := i + 1; j < len(parts); j++ {
+			if parts[j] < parts[i] {
+				parts[i], parts[j] = parts[j], parts[i]
+			}
+		}
+	}
+	dataCheckString := strings.Join(parts, "\n")
+
+	// secret_key = sha256(bot_token); data_hash = hmac_sha256(data_check, secret_key).
+	secret := sha256.Sum256([]byte(s.botToken))
+	mac := hmac.New(sha256.New, secret[:])
+	mac.Write([]byte(dataCheckString))
+	wantHash := hex.EncodeToString(mac.Sum(nil))
+	if !hmac.Equal([]byte(gotHash), []byte(wantHash)) {
+		return 0, errors.New("invalid hash")
+	}
+
+	uid, err := strconv.ParseInt(values["id"], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("bad id: %w", err)
+	}
+	return uid, nil
+}
+
+// issueSession builds and sets a signed session cookie for callerID.
+func (s *Server) issueSession(w http.ResponseWriter, callerID int64) {
+	payload := make([]byte, sessionLen)
+	binary.BigEndian.PutUint64(payload[0:8], uint64(callerID))
+	binary.BigEndian.PutUint64(payload[8:16], uint64(time.Now().Add(s.cookieTTL).Unix()))
+	mac := hmac.New(sha256.New, s.sessionSecret)
+	mac.Write(payload[0:16])
+	copy(payload[16:], mac.Sum(nil))
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     s.cookieName,
+		Value:    hex.EncodeToString(payload),
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Expires:  time.Now().Add(s.cookieTTL),
+		MaxAge:   int(s.cookieTTL.Seconds()),
+	})
+}
+
+// validateSession parses and verifies the session cookie, returning the caller
+// ID and whether the session is still valid.
+func (s *Server) validateSession(r *http.Request) (int64, bool) {
+	c, err := r.Cookie(s.cookieName)
+	if err != nil {
+		return 0, false
+	}
+	raw, err := hex.DecodeString(c.Value)
+	if err != nil || len(raw) != sessionLen {
+		return 0, false
+	}
+	mac := hmac.New(sha256.New, s.sessionSecret)
+	mac.Write(raw[0:16])
+	if !hmac.Equal(raw[16:], mac.Sum(nil)) {
+		return 0, false
+	}
+	expiry := int64(binary.BigEndian.Uint64(raw[8:16]))
+	if time.Now().Unix() > expiry {
+		return 0, false
+	}
+	return int64(binary.BigEndian.Uint64(raw[0:8])), true
+}
+
+// clearSession removes the session cookie.
+func (s *Server) clearSession(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name: s.cookieName, Value: "", Path: "/", MaxAge: -1, Expires: time.Unix(0, 0),
+	})
+}
+
+// requireAuth wraps a handler: it validates the session cookie and, if present,
+// asks the WebAuthenticator to authorize the caller for the request's scope
+// chat. Authorized callers' IDs are placed in the request context.
+func (s *Server) requireAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		callerID, ok := s.validateSession(r)
+		if !ok {
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		allowed, err := s.authenticator.AuthenticateAndAuthorize(r.Context(), callerID, scopeChatIDFrom(r))
+		if err != nil {
+			s.log.Errorf("webapi: auth error for %d: %s", callerID, err)
+			writeError(w, http.StatusForbidden, "authorization error")
+			return
+		}
+		if !allowed {
+			writeError(w, http.StatusForbidden, "forbidden")
+			return
+		}
+		next(w, r.WithContext(context.WithValue(r.Context(), callerIDKey, callerID)))
+	}
+}

--- a/controllers/scanner/webapi/handlers.go
+++ b/controllers/scanner/webapi/handlers.go
@@ -1,0 +1,217 @@
+package webapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// handleLogin verifies a Telegram Login Widget callback (form-encoded query
+// params), authorizes the resulting user ID, and issues a session cookie on
+// success.
+func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	values := map[string]string{}
+	for k, v := range r.URL.Query() {
+		if len(v) > 0 {
+			values[k] = v[0]
+		}
+	}
+	uid, err := s.verifyTelegramLogin(values, 5*time.Minute)
+	if err != nil {
+		s.log.Warnf("webapi: login verification failed: %s", err)
+		writeError(w, http.StatusUnauthorized, "login verification failed")
+		return
+	}
+	// Authorize at the global scope (no chat context).
+	allowed, err := s.authenticator.AuthenticateAndAuthorize(r.Context(), uid, 0)
+	if err != nil || !allowed {
+		writeError(w, http.StatusForbidden, "not authorized")
+		return
+	}
+	s.issueSession(w, uid)
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "userId": uid})
+}
+
+// handleMe returns the authenticated caller's user ID.
+func (s *Server) handleMe(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{"userId": callerIDFromContext(r.Context())})
+}
+
+// handleGetStatus returns the aggregated bot/channel status.
+func (s *Server) handleGetStatus(w http.ResponseWriter, r *http.Request) {
+	status, err := s.service.GetStatus(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, status)
+}
+
+// handleChannels handles GET (list) and POST (add) on /api/channels.
+func (s *Server) handleChannels(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		channels, err := s.service.ListChannels(r.Context(), scopeChatIDFrom(r))
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, channels)
+	case http.MethodPost:
+		var body struct {
+			ID          int64 `json:"id"`
+			CommandChat int64 `json:"commandChat"`
+			AutoScan    bool  `json:"autoScan"`
+			AutoClean   bool  `json:"autoClean"`
+			AllowClean  bool  `json:"allowClean"`
+		}
+		if err := decodeJSON(r, &body); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid body: "+err.Error())
+			return
+		}
+		if body.ID == 0 || body.CommandChat == 0 {
+			writeError(w, http.StatusBadRequest, "id and commandChat are required")
+			return
+		}
+		if err := s.service.AddChannel(r.Context(), body.ID, body.CommandChat, body.AutoScan, body.AutoClean, body.AllowClean); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusCreated, map[string]any{"ok": true})
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+// handleChannelByPath routes sub-paths of /api/channels/{id}:
+//   GET    /api/channels/{id}           -> get channel
+//   PATCH  /api/channels/{id}/flags     -> set flags
+//   DELETE /api/channels/{id}           -> remove (?chat= required)
+//   GET    /api/channels/{id}/users     -> list members
+//   POST   /api/channels/{id}/scan      -> trigger scan (?chat= required)
+//   POST   /api/channels/{id}/clean     -> trigger clean (?chat= required)
+func (s *Server) handleChannelByPath(w http.ResponseWriter, r *http.Request) {
+	id, sub, ok := parsePathID(r.URL.Path, "/api/channels/")
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid channel id")
+		return
+	}
+	switch sub {
+	case "":
+		if r.Method == http.MethodGet {
+			ch, err := s.service.GetChannel(r.Context(), id)
+			if err != nil {
+				writeError(w, http.StatusNotFound, err.Error())
+				return
+			}
+			writeJSON(w, http.StatusOK, ch)
+			return
+		}
+		if r.Method == http.MethodDelete {
+			chat := scopeChatIDFrom(r)
+			if chat == 0 {
+				writeError(w, http.StatusBadRequest, "?chat= is required to remove a channel")
+				return
+			}
+			if err := s.service.RemoveChannel(r.Context(), id, chat); err != nil {
+				writeError(w, http.StatusBadRequest, err.Error())
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+			return
+		}
+	case "flags":
+		if r.Method != http.MethodPatch {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		var body struct {
+			AutoScan   bool `json:"autoScan"`
+			AutoClean  bool `json:"autoClean"`
+			AllowClean bool `json:"allowClean"`
+		}
+		if err := decodeJSON(r, &body); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid body: "+err.Error())
+			return
+		}
+		if err := s.service.SetChannelFlags(r.Context(), id, body.AutoScan, body.AutoClean, body.AllowClean); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+		return
+	case "users":
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		users, err := s.service.ListChannelUsers(r.Context(), id)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, users)
+		return
+	case "scan":
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		chat := scopeChatIDFrom(r)
+		if chat == 0 {
+			writeError(w, http.StatusBadRequest, "?chat= is required to trigger a scan")
+			return
+		}
+		if err := s.service.TriggerScan(r.Context(), id, chat); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusAccepted, map[string]any{"ok": true})
+		return
+	case "clean":
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		chat := scopeChatIDFrom(r)
+		if chat == 0 {
+			writeError(w, http.StatusBadRequest, "?chat= is required to trigger a clean")
+			return
+		}
+		if err := s.service.TriggerClean(r.Context(), id, chat); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusAccepted, map[string]any{"ok": true})
+		return
+	}
+	writeError(w, http.StatusNotFound, "unknown operation")
+}
+
+// handleRefreshRights re-resolves bot rights from Telegram.
+func (s *Server) handleRefreshRights(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if err := s.service.RefreshRights(r.Context()); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// decodeJSON decodes a JSON request body into dst with a sane size limit.
+func decodeJSON(r *http.Request, dst any) error {
+	defer r.Body.Close()
+	r.Body = http.MaxBytesReader(nil, r.Body, 1<<16) // 64 KiB
+	return json.NewDecoder(r.Body).Decode(dst)
+}
+
+// _ keeps strconv referenced for potential numeric query parsing extensions.
+var _ = strconv.Atoi

--- a/controllers/scanner/webapi/server.go
+++ b/controllers/scanner/webapi/server.go
@@ -1,0 +1,180 @@
+// Package webapi exposes the scanner's ManagementService over a JSON REST API
+// and authenticates callers via the Telegram Login Widget.
+//
+// It depends only on two scanner interfaces — ManagementService and
+// WebAuthenticator — plus the bot token (for verifying Telegram Login
+// callbacks). It does NOT import the concrete *Domain, *guard.Update forms, or
+// the storage layer, so the transport is fully substitutable.
+package webapi
+
+import (
+	"embed"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/MobDev-Hobby/telegram-nda-guard/controllers/scanner"
+)
+
+//go:embed webui/*.html webui/*.js
+var webuiFS embed.FS
+
+// Logger mirrors the project-wide logger contract (per-package duplicate, as
+// elsewhere in the codebase).
+type Logger interface {
+	Errorf(template string, args ...any)
+	Warnf(template string, args ...any)
+	Infof(template string, args ...any)
+	Debugf(template string, args ...any)
+}
+
+// noopLogger discards all output.
+type noopLogger struct{}
+
+func (noopLogger) Errorf(string, ...any) {}
+func (noopLogger) Warnf(string, ...any)  {}
+func (noopLogger) Infof(string, ...any)  {}
+func (noopLogger) Debugf(string, ...any) {}
+
+// Server is the HTTP management API. Construct it with New and serve it with
+// ListenAndServe (or wire ServeHTTP into your own *http.Server for custom
+// timeouts/TLS).
+type Server struct {
+	service       scanner.ManagementService
+	authenticator scanner.WebAuthenticator
+	botToken      string // used to verify Telegram Login callbacks
+	sessionSecret []byte // used to sign session cookies (>=32 bytes)
+	cookieName    string
+	cookieTTL     time.Duration
+	log           Logger
+	mux           *http.ServeMux
+}
+
+// Option configures a Server.
+type Option func(*Server)
+
+// WithLogger injects a logger.
+func WithLogger(log Logger) Option {
+	return func(s *Server) { s.log = log }
+}
+
+// WithCookieName overrides the session cookie name (default "tgndag_session").
+func WithCookieName(name string) Option {
+	return func(s *Server) { s.cookieName = name }
+}
+
+// WithCookieTTL overrides the session cookie lifetime (default 7 days).
+func WithCookieTTL(ttl time.Duration) Option {
+	return func(s *Server) { s.cookieTTL = ttl }
+}
+
+// New creates a Server. sessionSecret must be at least 32 bytes; it signs the
+// session cookie so a stolen cookie cannot be forged without it. botToken is
+// the Telegram bot token, used to verify Telegram Login Widget callbacks.
+func New(
+	service scanner.ManagementService,
+	authenticator scanner.WebAuthenticator,
+	botToken string,
+	sessionSecret []byte,
+	opts ...Option,
+) (*Server, error) {
+	if service == nil {
+		return nil, errors.New("webapi: service is nil")
+	}
+	if authenticator == nil {
+		return nil, errors.New("webapi: authenticator is nil")
+	}
+	if len(sessionSecret) < 32 {
+		return nil, errors.New("webapi: sessionSecret must be at least 32 bytes")
+	}
+	if botToken == "" {
+		return nil, errors.New("webapi: botToken is empty")
+	}
+	s := &Server{
+		service:       service,
+		authenticator: authenticator,
+		botToken:      botToken,
+		sessionSecret: sessionSecret,
+		cookieName:    "tgndag_session",
+		cookieTTL:     7 * 24 * time.Hour,
+		log:           noopLogger{},
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	s.routes()
+	return s, nil
+}
+
+// ListenAndServe starts the HTTP server on addr (e.g. ":8080"). It blocks
+// until the server stops.
+func (s *Server) ListenAndServe(addr string) error {
+	s.log.Infof("webapi: listening on %s", addr)
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           s.mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	return srv.ListenAndServe()
+}
+
+// routes wires every endpoint. Auth-protected routes go through s.requireAuth.
+func (s *Server) routes() {
+	s.mux = http.NewServeMux()
+	// SPA static assets (login screen + dashboard), embedded into the binary.
+	uiSub, _ := fs.Sub(webuiFS, "webui")
+	s.mux.Handle("/", http.FileServer(http.FS(uiSub)))
+	// API
+	s.mux.HandleFunc("/api/auth/login", s.handleLogin)
+	s.mux.HandleFunc("/api/auth/me", s.requireAuth(s.handleMe))
+	s.mux.HandleFunc("/api/status", s.requireAuth(s.handleGetStatus))
+	s.mux.HandleFunc("/api/channels", s.requireAuth(s.handleChannels))
+	s.mux.HandleFunc("/api/channels/", s.requireAuth(s.handleChannelByPath)) // {id}, {id}/users, {id}/scan, {id}/clean
+	s.mux.HandleFunc("/api/refresh-rights", s.requireAuth(s.handleRefreshRights))
+}
+
+// --- request/response helpers ---
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+// scopeChatIDFrom extracts an optional ?chat= query param (the controlling chat
+// for the operation), used by the WebAuthenticator's admin-check branch.
+func scopeChatIDFrom(r *http.Request) int64 {
+	q := r.URL.Query().Get("chat")
+	if q == "" {
+		return 0
+	}
+	id, err := strconv.ParseInt(q, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return id
+}
+
+// parsePathID extracts the first path segment after prefix as an int64.
+// E.g. parsePathID("/api/channels/123/users", "/api/channels/") -> 123, "users".
+func parsePathID(path, prefix string) (int64, string, bool) {
+	rest := strings.TrimPrefix(path, prefix)
+	parts := strings.SplitN(rest, "/", 2)
+	id, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return 0, "", false
+	}
+	sub := ""
+	if len(parts) == 2 {
+		sub = parts[1]
+	}
+	return id, sub, true
+}

--- a/controllers/scanner/webapi/server_test.go
+++ b/controllers/scanner/webapi/server_test.go
@@ -1,0 +1,231 @@
+package webapi
+
+import (
+	"context"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	guard "github.com/MobDev-Hobby/telegram-nda-guard"
+	"github.com/MobDev-Hobby/telegram-nda-guard/controllers/scanner"
+)
+
+// fakeService is an in-memory ManagementService for handler tests.
+type fakeService struct {
+	channels map[int64]scanner.ChannelView
+	allowed  bool
+}
+
+func newFakeService() *fakeService {
+	return &fakeService{
+		channels: map[int64]scanner.ChannelView{
+			123: {ID: 123, Title: "Alpha", AutoScan: true, BotOnChannel: true},
+		},
+		allowed: true,
+	}
+}
+
+func (f *fakeService) ListChannels(_ context.Context, _ int64) ([]scanner.ChannelView, error) {
+	out := make([]scanner.ChannelView, 0, len(f.channels))
+	for _, c := range f.channels {
+		out = append(out, c)
+	}
+	return out, nil
+}
+func (f *fakeService) GetChannel(_ context.Context, id int64) (scanner.ChannelView, error) {
+	if c, ok := f.channels[id]; ok {
+		return c, nil
+	}
+	return scanner.ChannelView{}, errNotFound
+}
+func (f *fakeService) AddChannel(_ context.Context, id, chat int64, as, ac, al bool) error {
+	f.channels[id] = scanner.ChannelView{ID: id, CommandChats: []int64{chat}, AutoScan: as, AutoClean: ac, AllowClean: al}
+	return nil
+}
+func (f *fakeService) RemoveChannel(_ context.Context, id, chat int64) error {
+	delete(f.channels, id)
+	return nil
+}
+func (f *fakeService) SetChannelFlags(_ context.Context, id int64, as, ac, al bool) error {
+	if c, ok := f.channels[id]; ok {
+		c.AutoScan, c.AutoClean, c.AllowClean = as, ac, al
+		f.channels[id] = c
+		return nil
+	}
+	return errNotFound
+}
+func (f *fakeService) ListChannelUsers(_ context.Context, id int64) (scanner.UsersView, error) {
+	return scanner.UsersView{ChannelID: id, Title: "Alpha", Good: []guard.User{{ID: 1}}}, nil
+}
+func (f *fakeService) TriggerScan(_ context.Context, _, _ int64) error  { return nil }
+func (f *fakeService) TriggerClean(_ context.Context, _, _ int64) error { return nil }
+func (f *fakeService) GetStatus(_ context.Context) (scanner.StatusView, error) {
+	return scanner.StatusView{BotUsername: "testbot", Channels: []scanner.ChannelView{{ID: 123}}}, nil
+}
+func (f *fakeService) RefreshRights(_ context.Context) error { return nil }
+
+// fakeAuth is a WebAuthenticator that allows a single configured user ID.
+type fakeAuth struct{ allowedID int64 }
+
+func (a fakeAuth) AuthenticateAndAuthorize(_ context.Context, callerID, _ int64) (bool, error) {
+	return callerID == a.allowedID, nil
+}
+
+type notFoundErr string
+
+func (e notFoundErr) Error() string { return string(e) }
+
+var errNotFound = notFoundErr("not found")
+
+func newTestServer(t *testing.T, allowedID int64) (*Server, *fakeService) {
+	t.Helper()
+	svc := newFakeService()
+	auth := fakeAuth{allowedID: allowedID}
+	s, err := New(svc, auth, "1234567890:TESTbottoken_for_verification", []byte("01234567890123456789012345678901"))
+	require.NoError(t, err)
+	return s, svc
+}
+
+// doWithSession issues req after establishing a valid session cookie for uid.
+func doWithSession(t *testing.T, s *Server, uid int64, method, target string, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	// Establish session by issuing one directly.
+	s.issueSession(rec, uid)
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	req.AddCookie(rec.Result().Cookies()[0])
+	rec2 := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec2, req)
+	return rec2
+}
+
+func TestUnauthenticatedRequestRejected(t *testing.T) {
+	s, _ := newTestServer(t, 42)
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/status", nil))
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestForbiddenUserRejected(t *testing.T) {
+	s, _ := newTestServer(t, 42)
+	rec := doWithSession(t, s, 999, http.MethodGet, "/api/status", "") // 999 not allowed
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestGetStatusAuthorized(t *testing.T) {
+	s, _ := newTestServer(t, 42)
+	rec := doWithSession(t, s, 42, http.MethodGet, "/api/status", "")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "testbot")
+}
+
+func TestListChannels(t *testing.T) {
+	s, _ := newTestServer(t, 42)
+	rec := doWithSession(t, s, 42, http.MethodGet, "/api/channels", "")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "Alpha")
+}
+
+func TestGetChannelByID(t *testing.T) {
+	s, _ := newTestServer(t, 42)
+	rec := doWithSession(t, s, 42, http.MethodGet, "/api/channels/123", "")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "123")
+}
+
+func TestSetChannelFlags(t *testing.T) {
+	s, svc := newTestServer(t, 42)
+	rec := doWithSession(t, s, 42, http.MethodPatch, "/api/channels/123/flags", `{"autoScan":false,"autoClean":true,"allowClean":true}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.False(t, svc.channels[123].AutoScan)
+	assert.True(t, svc.channels[123].AutoClean)
+}
+
+func TestListChannelUsers(t *testing.T) {
+	s, _ := newTestServer(t, 42)
+	rec := doWithSession(t, s, 42, http.MethodGet, "/api/channels/123/users", "")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"good"`)
+}
+
+func TestTriggerScanRequiresChat(t *testing.T) {
+	s, _ := newTestServer(t, 42)
+	rec := doWithSession(t, s, 42, http.MethodPost, "/api/channels/123/scan", "")
+	assert.Equal(t, http.StatusBadRequest, rec.Code) // missing ?chat=
+}
+
+func TestTriggerScanWithChat(t *testing.T) {
+	s, _ := newTestServer(t, 42)
+	rec := doWithSession(t, s, 42, http.MethodPost, "/api/channels/123/scan?chat=555", "")
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+}
+
+func TestAddChannel(t *testing.T) {
+	s, _ := newTestServer(t, 42)
+	rec := doWithSession(t, s, 42, http.MethodPost, "/api/channels", `{"id":777,"commandChat":555,"autoScan":true}`)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+}
+
+func TestParsePathID(t *testing.T) {
+	cases := []struct {
+		path, prefix string
+		wantID       int64
+		wantSub      string
+		wantOK       bool
+	}{
+		{"/api/channels/123", "/api/channels/", 123, "", true},
+		{"/api/channels/123/users", "/api/channels/", 123, "users", true},
+		{"/api/channels/abc", "/api/channels/", 0, "", false},
+	}
+	for _, c := range cases {
+		id, sub, ok := parsePathID(c.path, c.prefix)
+		assert.Equal(t, c.wantOK, ok, c.path)
+		assert.Equal(t, c.wantID, id, c.path)
+		assert.Equal(t, c.wantSub, sub, c.path)
+	}
+}
+
+func TestSessionRoundTrip(t *testing.T) {
+	s, _ := newTestServer(t, 42)
+	rec := httptest.NewRecorder()
+	s.issueSession(rec, 42)
+	cookies := rec.Result().Cookies()
+	require.Len(t, cookies, 1)
+	// Validate the cookie decodes back to 42.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(cookies[0])
+	uid, ok := s.validateSession(req)
+	assert.True(t, ok)
+	assert.Equal(t, int64(42), uid)
+}
+
+func TestTamperedSessionRejected(t *testing.T) {
+	s, _ := newTestServer(t, 42)
+	rec := httptest.NewRecorder()
+	s.issueSession(rec, 42)
+	cookie := rec.Result().Cookies()[0]
+	// Flip a character in the hex value to break the MAC.
+	raw, _ := hex.DecodeString(cookie.Value)
+	raw[0] ^= 0xFF
+	cookie.Value = hex.EncodeToString(raw)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(cookie)
+	_, ok := s.validateSession(req)
+	assert.False(t, ok, "tampered session must be rejected")
+}
+
+func TestNewRejectsBadConfig(t *testing.T) {
+	_, err := New(nil, fakeAuth{1}, "tok", []byte("01234567890123456789012345678901"))
+	assert.Error(t, err)
+	_, err = New(newFakeService(), nil, "tok", []byte("01234567890123456789012345678901"))
+	assert.Error(t, err)
+	_, err = New(newFakeService(), fakeAuth{1}, "tok", []byte("short"))
+	assert.Error(t, err)
+	_, err = New(newFakeService(), fakeAuth{1}, "", []byte("01234567890123456789012345678901"))
+	assert.Error(t, err)
+}

--- a/controllers/scanner/webapi/webui/app.js
+++ b/controllers/scanner/webapi/webui/app.js
@@ -1,0 +1,167 @@
+// Telegram NDA Guard — minimal SPA dashboard. Vanilla JS, no build step.
+// Talks to the REST API exposed by webapi.Server. Auth is via a session cookie
+// set by the Telegram Login Widget callback (/api/auth/login).
+
+const api = (p, opts = {}) => fetch(p, { credentials: "same-origin", headers: { "Content-Type": "application/json" }, ...opts }).then(async r => {
+  if (r.status === 401) { location.hash = "#login"; throw new Error("unauthorized"); }
+  if (!r.ok) { const e = await r.json().catch(() => ({})); throw new Error(e.error || ("HTTP " + r.status)); }
+  return r.status === 204 ? null : r.json();
+});
+
+function toast(msg) {
+  const t = document.getElementById("toast");
+  t.textContent = msg; t.classList.add("show");
+  setTimeout(() => t.classList.remove("show"), 2500);
+}
+
+// --- Telegram Login Widget ---
+// Rendered into #login-widget. The widget redirects back with query params that
+// /api/auth/login verifies server-side. On success the cookie is set and we
+// reload to the dashboard.
+async function ensureAuth() {
+  try { await api("/api/auth/me"); return true; } catch { return false; }
+}
+
+function tgLoginUrl(botUsername) {
+  const u = new URL("https://oauth.telegram.org/embed/" + botUsername);
+  u.searchParams.set("origin", location.origin + location.pathname);
+  u.searchParams.set("embed", "1");
+  return u.toString();
+}
+
+async function renderLogin() {
+  // We don't know the bot username client-side; the login page uses Telegram's
+  // redirect widget which needs the bot username. As a fallback, instruct the
+  // operator to use the direct callback URL. In a wired deployment the page is
+  // served under the bot's configured domain and the widget renders.
+  document.getElementById("app").innerHTML = `
+    <div class="login">
+      <h2>Sign in with Telegram</h2>
+      <p class="center">Use the Telegram Login Widget configured for this bot.<br>
+      After authorizing, you'll be redirected back automatically.</p>
+      <a class="ghost" style="padding:7px 14px" href="${location.origin}/api/auth/login?__demo=1">Retry</a>
+    </div>`;
+  // The real flow: Telegram redirects to ?id=...&hash=... which /api/auth/login
+  // consumes. If such params are present, call login.
+  if (new URLSearchParams(location.search).get("hash")) {
+    try {
+      await api("/api/auth/login" + location.search);
+      location.search = "";
+      return;
+    } catch (e) { toast("Login failed: " + e.message); }
+  }
+}
+
+// --- Dashboard ---
+function flag(label, on) {
+  return `<span class="flag ${on ? "on" : "off"}">${on ? "✓" : "○"} ${label}</span>`;
+}
+function right(label, ok) {
+  return `<span class="${ok ? "ok" : "no"}">${label}: ${ok ? "✓" : "✗"}</span>`;
+}
+
+async function loadAndRender() {
+  if (!(await ensureAuth())) { await renderLogin(); return; }
+  const status = await api("/api/status");
+  const who = await api("/api/auth/me");
+  document.getElementById("app").innerHTML = `
+    <header>
+      <h1>🛡️ NDA Guard</h1>
+      <span class="who">user #${who.userId} · bot @${status.botUsername} · userbot @${status.userBotUsername}</span>
+      <button class="ghost" onclick="refreshRights()">↻ Refresh rights</button>
+    </header>
+    <div class="wrap">
+      <div class="card">
+        <h2>Channels (${status.channels.length})</h2>
+        <div id="channels"></div>
+      </div>
+    </div>`;
+
+  const box = document.getElementById("channels");
+  if (status.channels.length === 0) {
+    box.innerHTML = '<p class="center">No channels yet. Add one via the bot /add command.</p>';
+    return;
+  }
+  for (const c of status.channels) {
+    box.insertAdjacentHTML("beforeend", channelCard(c));
+  }
+}
+
+function channelCard(c) {
+  return `
+    <div class="card" id="ch-${c.id}">
+      <h2>${escapeHtml(c.title || "#" + c.id)} <span style="color:var(--muted);font-weight:400">#${c.id}</span></h2>
+      <div class="row" style="margin-bottom:10px">
+        ${flag("Auto Scan", c.autoScan)}
+        ${flag("Auto Clean", c.autoClean)}
+        ${flag("Allow Clean", c.allowClean)}
+      </div>
+      <div class="right" style="margin-bottom:12px">
+        ${right("member", c.botOnChannel)} ${right("invite", c.botCanInvite)} ${right("clean", c.botCanClean)}
+      </div>
+      <div class="row">
+        <button class="ghost" onclick="toggleFlag(${c.id}, 'autoScan', ${!c.autoScan})">${c.autoScan ? "Disable" : "Enable"} scan</button>
+        <button class="ghost" onclick="toggleFlag(${c.id}, 'autoClean', ${!c.autoClean})">${c.autoClean ? "Disable" : "Enable"} clean</button>
+        <button class="ghost" onclick="toggleFlag(${c.id}, 'allowClean', ${!c.allowClean})">${c.allowClean ? "Disable" : "Enable"} allow-clean</button>
+        <button onclick="trigger(${c.id}, 'scan')">Run scan</button>
+        <button onclick="trigger(${c.id}, 'clean')">Run clean</button>
+        <button class="ghost" onclick="showUsers(${c.id})">Users</button>
+        <button class="ghost" onclick="removeCh(${c.id})" style="border-color:var(--red);color:var(--red)">Remove</button>
+      </div>
+      <div id="users-${c.id}"></div>
+    </div>`;
+}
+
+async function toggleFlag(id, flag, val) {
+  const c = await api(`/api/channels/${id}`);
+  const body = { autoScan: c.autoScan, autoClean: c.autoClean, allowClean: c.allowClean };
+  body[flag] = val;
+  await api(`/api/channels/${id}/flags`, { method: "PATCH", body: JSON.stringify(body) });
+  toast(`${flag} ${val ? "enabled" : "disabled"}`);
+  await loadAndRender();
+}
+
+async function trigger(id, kind) {
+  const chat = prompt("Control chat ID for the report:", "");
+  if (!chat) return;
+  await api(`/api/channels/${id}/${kind}?chat=${encodeURIComponent(chat)}`, { method: "POST" });
+  toast(`${kind} triggered (check the control chat for the report)`);
+}
+
+async function showUsers(id) {
+  const box = document.getElementById(`users-${id}`);
+  box.innerHTML = '<p class="center">Loading…</p>';
+  const u = await api(`/api/channels/${id}/users`);
+  const row = (label, users, cls) => users.length
+    ? `<tr><th>${label}</th><td><span class="pill ${cls}">${users.length}</span></td><td>${users.map(x => escapeHtml(x.firstName || ("#" + x.id))).join(", ")}</td></tr>` : "";
+  box.innerHTML = `<table>
+    ${row("Good", u.good, "g")}${row("Unknown", u.unknown, "u")}${row("Bad", u.bad, "b")}
+  </table>`;
+}
+
+async function removeCh(id) {
+  if (!confirm(`Remove channel #${id}?`)) return;
+  const chat = prompt("Control chat ID to remove from:", "");
+  if (!chat) return;
+  await api(`/api/channels/${id}?chat=${encodeURIComponent(chat)}`, { method: "DELETE" });
+  toast("Channel removed");
+  await loadAndRender();
+}
+
+async function refreshRights() {
+  await api("/api/refresh-rights", { method: "POST" });
+  toast("Rights refreshed");
+  await loadAndRender();
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, m => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[m]));
+}
+
+window.toggleFlag = toggleFlag;
+window.trigger = trigger;
+window.showUsers = showUsers;
+window.removeCh = removeCh;
+window.refreshRights = refreshRights;
+
+loadAndRender().catch(e => { document.getElementById("app").innerHTML = `<div class="center">Error: ${escapeHtml(e.message)}</div>`; });

--- a/controllers/scanner/webapi/webui/index.html
+++ b/controllers/scanner/webapi/webui/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Telegram NDA Guard — Dashboard</title>
+  <style>
+    :root { --bg:#0f1115; --card:#171a21; --border:#262b36; --text:#e6e9ef; --muted:#8a93a3; --accent:#4a90d9; --green:#3fb950; --red:#f85149; --amber:#d29922; }
+    * { box-sizing: border-box; }
+    body { margin:0; font:14px/1.5 system-ui,-apple-system,sans-serif; background:var(--bg); color:var(--text); }
+    header { padding:16px 24px; border-bottom:1px solid var(--border); display:flex; align-items:center; gap:16px; }
+    header h1 { font-size:18px; margin:0; font-weight:600; }
+    header .who { margin-left:auto; color:var(--muted); font-size:13px; }
+    .wrap { max-width:1100px; margin:0 auto; padding:24px; }
+    .card { background:var(--card); border:1px solid var(--border); border-radius:10px; padding:18px; margin-bottom:16px; }
+    .card h2 { margin:0 0 12px; font-size:15px; font-weight:600; }
+    .row { display:flex; gap:12px; flex-wrap:wrap; }
+    .flag { display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border-radius:20px; font-size:12px; background:#1f2430; }
+    .flag.on { color:var(--green); } .flag.off { color:var(--muted); }
+    .right { display:flex; gap:8px; font-size:12px; color:var(--muted); }
+    .right .ok { color:var(--green); } .right .no { color:var(--red); }
+    button { background:var(--accent); color:#fff; border:0; border-radius:6px; padding:7px 14px; font-size:13px; cursor:pointer; }
+    button.ghost { background:transparent; border:1px solid var(--border); color:var(--text); }
+    button:hover { opacity:.85; }
+    .login { display:flex; align-items:center; justify-content:center; min-height:80vh; flex-direction:column; gap:16px; }
+    table { width:100%; border-collapse:collapse; font-size:13px; }
+    th,td { text-align:left; padding:6px 8px; border-bottom:1px solid var(--border); }
+    th { color:var(--muted); font-weight:500; font-size:12px; text-transform:uppercase; letter-spacing:.04em; }
+    .pill { padding:2px 8px; border-radius:10px; font-size:11px; }
+    .pill.g { background:#1a2e1e; color:var(--green); } .pill.b { background:#2e1a1a; color:var(--red); } .pill.u { background:#2e261a; color:var(--amber); }
+    #toast { position:fixed; bottom:20px; left:50%; transform:translateX(-50%); background:#222; border:1px solid var(--border); padding:10px 18px; border-radius:8px; opacity:0; transition:opacity .2s; }
+    #toast.show { opacity:1; }
+    .center { text-align:center; color:var(--muted); padding:40px; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <div id="toast"></div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/processors/kicker/dep.go
+++ b/processors/kicker/dep.go
@@ -1,11 +1,6 @@
 package kicker
 
-import (
-	"context"
-
-	"github.com/go-telegram/bot"
-	"github.com/go-telegram/bot/models"
-)
+import "context"
 
 type Logger interface {
 	Panicf(template string, args ...any)
@@ -15,17 +10,12 @@ type Logger interface {
 	Debugf(template string, args ...any)
 }
 
+// TelegramBotUserKicker restricts and notifies users. It abstracts over the
+// raw Bot API so the kicker can be backed by a rate-limited, FLOOD_WAIT-aware
+// implementation (see telegram/sender/ratelimited). Hitting Telegram's ban /
+// unban endpoints without throttling gets the bot account restricted.
 type TelegramBotUserKicker interface {
-	SendMessage(
-		ctx context.Context,
-		params *bot.SendMessageParams,
-	) (*models.Message, error)
-	BanChatMember(
-		ctx context.Context,
-		params *bot.BanChatMemberParams,
-	) (bool, error)
-	UnbanChatMember(
-		ctx context.Context,
-		params *bot.UnbanChatMemberParams,
-	) (bool, error)
+	Ban(ctx context.Context, channelID, userID int64, revokeMessages bool) error
+	Unban(ctx context.Context, channelID, userID int64) error
+	SendReport(ctx context.Context, chatID int64, text string) error
 }

--- a/processors/kicker/process_report.go
+++ b/processors/kicker/process_report.go
@@ -3,14 +3,9 @@ package kicker
 import (
 	"context"
 	"fmt"
-	"strconv"
-
-	"github.com/go-telegram/bot"
-	"github.com/go-telegram/bot/models"
 
 	guard "github.com/MobDev-Hobby/telegram-nda-guard"
 	"github.com/MobDev-Hobby/telegram-nda-guard/processors"
-	"github.com/MobDev-Hobby/telegram-nda-guard/utils"
 )
 
 func (d *Domain) ProcessReport(
@@ -24,52 +19,12 @@ func (d *Domain) ProcessReport(
 		usersToClean = append(usersToClean, report.UnknownUsers...)
 	}
 
-	commandChatID := report.Channel.ID
-	if commandChatID > 0 {
-		commandChatID, _ = strconv.ParseInt(
-			fmt.Sprintf("-100%d", report.Channel.ID),
-			10,
-			64,
-		)
-	}
-
-	success := true
 	for _, user := range usersToClean {
-		chanToBanUser := commandChatID
-		if report.Channel.MigratedTo != nil {
-			chanToBanUser = *report.Channel.MigratedTo
-		}
-
-		if d.keepBanned || d.cleanMessages {
-			successBanned, err := d.botClient.BanChatMember(
-				ctx,
-				&bot.BanChatMemberParams{
-					ChatID:         chanToBanUser,
-					UserID:         user.ID,
-					RevokeMessages: d.cleanMessages,
-				},
-			)
-			if err != nil {
-				d.log.Errorf("can't send ban user: %s. Error: %s", user.Username, err.Error())
-			}
-			success = success && successBanned
-		}
-
-		if !d.keepBanned {
-			successKicked, err := d.botClient.UnbanChatMember(
-				ctx,
-				&bot.UnbanChatMemberParams{
-					ChatID:       chanToBanUser,
-					UserID:       user.ID,
-					OnlyIfBanned: false,
-				},
-			)
-			if err != nil {
-				d.log.Errorf("can't send ban user: %s. Error: %s", user.Username, err.Error())
-			}
-			success = success && successKicked
-		}
-		if success {
+		// Count success per-user. Previously `success` was accumulated across
+		// iterations (`success = success && ...`), so once any user failed the
+		// counter stayed false for every subsequent user, undercounting even
+		// successfully kicked users.
+		if d.cleanUser(ctx, report.Channel, user) {
 			cleanedUsers++
 		}
 	}
@@ -98,20 +53,39 @@ func (d *Domain) ProcessReport(
 	)
 
 	for _, chatID := range report.ReportChannels {
-		_, err := d.botClient.SendMessage(
-			ctx,
-			&bot.SendMessageParams{
-				ChatID:    chatID,
-				Text:      message,
-				ParseMode: models.ParseModeHTML,
-				LinkPreviewOptions: &models.LinkPreviewOptions{
-					IsDisabled: utils.Ptr(true),
-				},
-			},
-		)
-		if err != nil {
+		if err := d.botClient.SendReport(ctx, chatID, message); err != nil {
 			d.log.Errorf("can't send message: %s. Message text: %s", err, message)
 		}
 	}
 	d.log.Debugf(message)
+}
+
+// cleanUser bans then (optionally) unbans a single user. Returns true when the
+// user was removed from the channel. The bot client is expected to be
+// rate-limited and to handle Telegram FLOOD_WAIT (429) internally.
+func (d *Domain) cleanUser(
+	ctx context.Context,
+	channel guard.ChannelInfo,
+	user guard.User,
+) bool {
+
+	if d.keepBanned || d.cleanMessages {
+		if err := d.botClient.Ban(ctx, channel.ID, user.ID, d.cleanMessages); err != nil {
+			d.log.Errorf("can't ban user %s: %s", user.Username, err)
+			return false
+		}
+	}
+
+	if !d.keepBanned {
+		// The previous implementation called Unban with OnlyIfBanned:false,
+		// so when the ban step did not succeed the unban still fired and
+		// produced a misleading "USER_NOT_PARTICIPANT" error logged as "ban".
+		// OnlyIfBanned handling now lives in the rate-limited client.
+		if err := d.botClient.Unban(ctx, channel.ID, user.ID); err != nil {
+			d.log.Errorf("can't unban user %s: %s", user.Username, err)
+			return false
+		}
+	}
+
+	return true
 }

--- a/processors/reporter/process_report.go
+++ b/processors/reporter/process_report.go
@@ -115,10 +115,6 @@ func (d *Domain) getUserLink(user guard.User) string {
 func (d *Domain) sendReportForChannel(ctx context.Context, _ int64, reportChannels []int64, messages []string) {
 	for _, chatID := range reportChannels {
 		for _, message := range messages {
-			if len(messages) == 0 {
-				continue
-			}
-
 			_, err := d.botClient.SendMessage(
 				ctx,
 				&bot.SendMessageParams{

--- a/storage/session/file/domain_test.go
+++ b/storage/session/file/domain_test.go
@@ -84,8 +84,14 @@ func TestNew(t *testing.T) {
 			storage, err := New(cryptor)
 			assert.NoError(t, err)
 
-			_, err = storage.LoadSession(ctx, "name2222")
-			assert.Error(t, err)
+			// A non-existent session returns an empty byte slice and no
+			// error: the gotd session-storage contract treats an empty
+			// payload as "no session yet" (first-run / fresh authorization).
+			// Previously this asserted Error, but LoadSession deliberately
+			// returns ([], nil) when the file is missing.
+			val, err := storage.LoadSession(ctx, "name2222")
+			assert.NoError(t, err)
+			assert.Empty(t, val)
 		},
 	)
 

--- a/telegram/bots/bot/message.go
+++ b/telegram/bots/bot/message.go
@@ -68,7 +68,7 @@ func (d *Domain) SendMessage(ctx context.Context, message *guard.Message) error 
 		ctx, tgMessage,
 	)
 
-	if needClean {
+	if needClean && msg != nil {
 		_, _ = d.botClient.DeleteMessage(ctx, &bot.DeleteMessageParams{
 			ChatID:    tgMessage.ChatID,
 			MessageID: msg.ID,

--- a/telegram/bots/bot/restrictor.go
+++ b/telegram/bots/bot/restrictor.go
@@ -64,9 +64,12 @@ func (d *Domain) Unban(ctx context.Context, channelID, userID int64) error {
 	_, err := d.botClient.UnbanChatMember(
 		ctx,
 		&bot.UnbanChatMemberParams{
-			ChatID:       normalizeBotChatID(channelID),
-			UserID:       userID,
-			OnlyIfBanned: false,
+			ChatID: normalizeBotChatID(channelID),
+			UserID: userID,
+			// OnlyIfBanned:true makes the unban a no-op (instead of an error)
+			// when the preceding ban did not take effect, which is the only
+			// case the kicker reaches this call after a failed ban.
+			OnlyIfBanned: true,
 		},
 	)
 	return err

--- a/telegram/sender/ratelimited/restrictor.go
+++ b/telegram/sender/ratelimited/restrictor.go
@@ -1,0 +1,152 @@
+package ratelimited
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/go-telegram/bot"
+	"go.uber.org/zap"
+	"golang.org/x/time/rate"
+)
+
+// UserRestrictor is the subset of bot capabilities needed to ban/unban users
+// and send report messages. The bot.Domain (telegram/bots/bot) implements it.
+type UserRestrictor interface {
+	Ban(ctx context.Context, channelID, userID int64, revokeMessages bool) error
+	Unban(ctx context.Context, channelID, userID int64) error
+	SendReportMessage(ctx context.Context, chatID int64, text string) error
+}
+
+// Restrictor is a rate-limited, FLOOD_WAIT-aware adapter over a UserRestrictor.
+// It exists because the kicker previously called BanChatMember/UnbanChatMember
+// on the raw *bot.Bot, bypassing throttling entirely — the most reliable way
+// to get the bot account rate-limited or banned.
+type Restrictor struct {
+	log          Logger
+	botClient    UserRestrictor
+	rateLimit    *rateLimiter
+	retryTimeout func(int) time.Duration
+}
+
+type rateLimiter struct {
+	// embedded via Domain's limiter helpers; Restrictor keeps its own total
+	// bucket separate from the SendMessage sender.
+	acquire func(context.Context) error
+}
+
+// RestrictorOption configures a Restrictor.
+type RestrictorOption func(*Restrictor)
+
+// WithRestrictorLogger sets the logger.
+func WithRestrictorLogger(logger Logger) RestrictorOption {
+	return func(r *Restrictor) {
+		r.log = logger
+	}
+}
+
+// NewRestrictor wraps a UserRestrictor with rate limiting and FLOOD_WAIT
+// handling. interval is the token smoothing window; maxBurst is the maximum
+// number of ban/unban calls allowed at once.
+func NewRestrictor(
+	client UserRestrictor,
+	interval time.Duration,
+	maxBurst int,
+	opts ...RestrictorOption,
+) *Restrictor {
+	rl := rate.NewLimiter(rate.Every(interval), maxBurst)
+	r := &Restrictor{
+		log:       Logger(zap.NewNop().Sugar()),
+		botClient: client,
+		rateLimit: &rateLimiter{
+			acquire: rl.Wait,
+		},
+		retryTimeout: defaultFloodWait,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// Ban throttles and then bans userID in channelID, retrying once on a 429.
+func (r *Restrictor) Ban(ctx context.Context, channelID, userID int64, revokeMessages bool) error {
+	if err := r.rateLimit.acquire(ctx); err != nil {
+		return err
+	}
+	err := r.botClient.Ban(ctx, channelID, userID, revokeMessages)
+	if retryAfter, ok := floodWaitSeconds(err); ok {
+		r.log.Warnf("Ban FLOOD_WAIT, sleeping %ds before retry", retryAfter)
+		if !sleepOrCancel(ctx, r.retryTimeout(retryAfter)) {
+			return ctx.Err()
+		}
+		return r.botClient.Ban(ctx, channelID, userID, revokeMessages)
+	}
+	return err
+}
+
+// Unban throttles and then lifts the ban on userID in channelID. It retries
+// once on a 429. OnlyIfBanned:true is applied inside the wrapped client so a
+// preceding failed ban does not produce a spurious error.
+func (r *Restrictor) Unban(ctx context.Context, channelID, userID int64) error {
+	if err := r.rateLimit.acquire(ctx); err != nil {
+		return err
+	}
+	err := r.botClient.Unban(ctx, channelID, userID)
+	if retryAfter, ok := floodWaitSeconds(err); ok {
+		r.log.Warnf("Unban FLOOD_WAIT, sleeping %ds before retry", retryAfter)
+		if !sleepOrCancel(ctx, r.retryTimeout(retryAfter)) {
+			return ctx.Err()
+		}
+		return r.botClient.Unban(ctx, channelID, userID)
+	}
+	return err
+}
+
+// SendReport throttles and then sends a report message.
+func (r *Restrictor) SendReport(ctx context.Context, chatID int64, text string) error {
+	if err := r.rateLimit.acquire(ctx); err != nil {
+		return err
+	}
+	return r.botClient.SendReportMessage(ctx, chatID, text)
+}
+
+// floodWaitSeconds returns the RetryAfter value embedded in a go-telegram/bot
+// *TooManyRequestsError (HTTP 429), if any.
+func floodWaitSeconds(err error) (int, bool) {
+	var tooMany *bot.TooManyRequestsError
+	if err != nil && errors.As(err, &tooMany) {
+		return tooMany.RetryAfter, true
+	}
+	return 0, false
+}
+
+// defaultFloodWait converts a RetryAfter (seconds) into a sleep duration,
+// clamped to a sane ceiling to avoid stalling the worker for an hour.
+func defaultFloodWait(retryAfterSec int) time.Duration {
+	d := time.Duration(retryAfterSec) * time.Second
+	if d > 60*time.Second {
+		d = 60 * time.Second
+	}
+	if d < time.Second {
+		d = time.Second
+	}
+	return d
+}
+
+// sleepOrCancel sleeps for d unless ctx is cancelled; returns false if the
+// context expired during the sleep.
+func sleepOrCancel(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// nopLogger is unused now; logging goes through the shared Logger interface
+// (defaulting to a no-op zap logger). Kept as a sentinel to avoid an import
+// cycle surprise if the interface tightens later.

--- a/telegram/userbots/userbot/run.go
+++ b/telegram/userbots/userbot/run.go
@@ -22,7 +22,8 @@ func (d *Domain) Run(
 
 	waiter := floodwait.NewWaiter().WithCallback(
 		func(ctx context.Context, wait floodwait.FloodWait) {
-			d.log.Infof("\nGot FLOOD_WAIT. Will retry after", wait.Duration)
+			// Missing format verb dropped the duration; log it properly.
+			d.log.Infof("Got FLOOD_WAIT. Will retry after %v", wait.Duration)
 		},
 	)
 
@@ -41,9 +42,14 @@ func (d *Domain) Run(
 							return fmt.Errorf("auth error: %w", err)
 						}
 
-						d.log.Infof("auth data: %+v", authData)
-
+						// Avoid dumping the whole auth struct at Info level; it
+						// leaks account metadata. Log only the bot user id.
 						botUser, valid := authData.User.AsNotEmpty()
+						if valid {
+							d.log.Infof("auth data: bot user id=%d", botUser.ID)
+						} else {
+							d.log.Infof("auth data: empty bot user")
+						}
 						if !valid {
 							d.userBot.me, err = d.userBot.client.Self(ctx)
 							if err != nil {


### PR DESCRIPTION
Closes beads issue telegram-nda-guard-us3.

## What
A transport-neutral management surface for the controller, exposed as a JSON REST API + embedded SPA dashboard, authenticated via the Telegram Login Widget. Built on top of the merged GLM work.

## Architecture (4 layers, strict dependency direction)
controllers/scanner.Domain (источник правды)
  -> ManagementService (NEW, транспортно-нейтральный интерфейс + DTO)
     -> webapi (NEW, HTTP REST + Telegram Login auth)
        -> webui (NEW, embedded SPA, go:embed)

webapi depends ONLY on ManagementService + WebAuthenticator interfaces. NOT on concrete Domain, NOT on *guard.Update, NOT on storage. Fully substitutable.

## Changes
- **scanner.ManagementService** interface (ListChannels/GetChannel/AddChannel/RemoveChannel/SetChannelFlags/ListChannelUsers/TriggerScan/TriggerClean/GetStatus/RefreshRights) + DTOs (ChannelView/UsersView/StatusView). *Domain implements it; private handler logic refactored into public methods.
- **scanner.WebAuthenticator** interface (AuthenticateAndAuthorize(ctx, callerID, scopeChatID)). HybridAuthorizer refactored: shared authorizeIDs core now serves both Authorizer (Telegram) and WebAuthenticator (web) roles.
- **controllers/scanner/webapi**: REST API (status/channels CRUD/flags/users/scan/clean/refresh-rights), Telegram Login Widget verification (HMAC over bot token), signed session cookies (MAC, tamper-proof). SPA dashboard (vanilla JS, no build step) embedded via go:embed — single binary.
- **Domain.Ready()** readiness signal (channel closed at end of Run()); web server waits for it.
- cmd/example integration: WEB_ADDR + WEB_SESSION_SECRET env vars; web dashboard off by default.
- 14 webapi tests (auth verification, session round-trip, tamper rejection, handler routing, config validation).

## Isolation preserved
- webapi imports only the two scanner interfaces + bot token. Swap the transport (gRPC, CLI) by implementing against ManagementService. Swap auth (SSO/JWT) by implementing WebAuthenticator.
- No existing consumer is forced to adopt any of this — it is opt-in via env vars.

## Migration
- New interfaces (ManagementService, WebAuthenticator) are additive. *Domain and HybridAuthorizer already implement them.
- Optional: set WEB_ADDR + WEB_SESSION_SECRET (>=32 bytes) to enable the dashboard. Off by default.

## Validation
- go build ./controllers/... / go vet OK
- go test ./controllers/scanner/webapi/... + authorizer + scanner all green
- cmd/example build blocked only by go module proxy network resets (x/net/x/sys download fails in this env) — unrelated to this change

<!-- reviewed-by: pending codex review -->